### PR TITLE
Fix #65: Refactor category pill tooltip rendering

### DIFF
--- a/src/components/CategoryPillComponent.tsx
+++ b/src/components/CategoryPillComponent.tsx
@@ -159,17 +159,18 @@ class CategoryPillComponent extends React.Component<CategoryPillProps, CategoryP
             this.tooltip.close();
         }
 
-        const tooltipMount = document.querySelector("#above-the-fold, ytm-slim-owner-renderer") as HTMLElement;
+        const tooltipMount = document.querySelector("#viewbox_report") as HTMLElement;
         if (tooltipMount) {
             this.tooltip = new Tooltip({
                 text: this.getTitleText(),
                 referenceNode: tooltipMount,
-                bottomOffset: "0px",
+                bottomOffset: "unset",
+                topOffset: "4px",
                 opacity: 0.95,
                 displayTriangle: false,
                 showLogo: false,
                 showGotIt: false,
-                prependElement: tooltipMount.firstElementChild as HTMLElement,
+                prependElement: tooltipMount.childNodes[1] as HTMLElement,
             });
         }
     }


### PR DESCRIPTION
- [x] 我同意我的所有贡献将以GPL-3.0协议开源。

***

此 Pull Request 修改了位于 `src/components/CategoryPillComponent.tsx` 中的 `CategoryPillComponent`，以修复 #65 提到的提示框不显示问题。

代码修改包括：

- 将工具提示挂载的查询选择器从 `"#above-the-fold, ytm-slim-owner-renderer"` 更改为 `"#viewbox_report"`，适配Bilibili网页布局。
- 将 `bottomOffset` 从 `"0px"` 更新为 `"unset"`，并添加了 `topOffset` 为 `"4px"`，以改善工具提示的位置。
- 修改 `prependElement` 使用第二个子节点而不是第一个元素子节点，以确保正确的工具提示附着。