### PR TITLE
Fix #72: Refactor thumbnail label update methods

### DIFF
--- a/src/thumbnail-utils/thumbnailManagement.ts
+++ b/src/thumbnail-utils/thumbnailManagement.ts
@@ -3,7 +3,7 @@ import { waitFor } from "../utils/";
 import { addCleanupListener } from "../utils/cleanup";
 import { getPageType } from "../utils/video";
 import { getThumbnailContainerElements, getThumbnailLink, getThumbnailSelectors } from "./thumbnail-selectors";
-import { insertSBIconDefinition, labelThumbnails } from "./thumbnails";
+import { insertSBIconDefinition, labelThumbnail, labelThumbnails } from "./thumbnails";
 
 export type ThumbnailListener = (newThumbnails: HTMLElement[]) => void;
 
@@ -83,7 +83,7 @@ export function newThumbnails() {
             const observer = new MutationObserver((mutations) => {
                 for (const mutation of mutations) {
                     if (mutation.type === "attributes" && mutation.attributeName === "href") {
-                        labelThumbnails([thumbnail]);
+                        labelThumbnail(thumbnail as HTMLImageElement, mutation.oldValue);
                         break;
                     }
                 }
@@ -91,7 +91,7 @@ export function newThumbnails() {
             handledThumbnailsObserverMap.set(thumbnail, observer);
 
             const link = getThumbnailLink(thumbnail);
-            if (link) observer.observe(link, { attributes: true });
+            if (link) observer.observe(link, { attributes: true, attributeOldValue: true, attributeFilter: ["href"] });
         }
     }
 

--- a/src/thumbnail-utils/thumbnails.ts
+++ b/src/thumbnail-utils/thumbnails.ts
@@ -7,7 +7,10 @@ export async function labelThumbnails(thumbnails: HTMLElement[]): Promise<void> 
     await Promise.all(thumbnails.map((t) => labelThumbnail(t as HTMLImageElement)));
 }
 
-export async function labelThumbnail(thumbnail: HTMLImageElement): Promise<HTMLElement | null> {
+export async function labelThumbnail(
+    thumbnail: HTMLImageElement,
+    thumbnailOldHref?: string
+): Promise<HTMLElement | null> {
     if (!Config.config?.fullVideoSegments || !Config.config?.fullVideoLabelsOnThumbnails) {
         hideThumbnailLabel(thumbnail);
         return null;
@@ -28,13 +31,21 @@ export async function labelThumbnail(thumbnail: HTMLImageElement): Promise<HTMLE
     }
     const [videoID] = videoIDs;
 
+    // 获取或创建缩略图标签
+    const { overlay, text } = await createOrGetThumbnail(thumbnail);
+
+    if (thumbnailOldHref) {
+        const oldVideoID = getBvIDFromURL(thumbnailOldHref);
+        if (oldVideoID && oldVideoID == videoID) {
+            return overlay;
+        }
+    }
+
     const category = await getVideoLabel(videoID);
     if (!category) {
         hideThumbnailLabel(thumbnail);
         return null;
     }
-
-    const { overlay, text } = await createOrGetThumbnail(thumbnail);
 
     overlay.style.setProperty(
         "--category-color",
@@ -51,7 +62,7 @@ export async function labelThumbnail(thumbnail: HTMLImageElement): Promise<HTMLE
 }
 
 function getOldThumbnailLabel(thumbnail: HTMLImageElement): HTMLElement | null {
-    return thumbnail.querySelector(".sponsorThumbnailLabel") as HTMLElement | null;
+    return thumbnail.querySelector("#sponsorThumbnailLabel") as HTMLElement | null;
 }
 
 function hideThumbnailLabel(thumbnail: HTMLImageElement): void {


### PR DESCRIPTION
- [x] 我同意我的所有贡献将以GPL-3.0协议开源。

***
本次 Pull Request 包括对缩略图管理和标签功能的更新，重点是优化 labelThumbnail 函数并改进缩略图更新的处理，以解决 #72 相关问题。

### 缩略图管理增强：

* `src/thumbnail-utils/thumbnailManagement.ts`：将 `labelThumbnails` 更新为 `labelThumbnail` 以支持单个缩略图的更新，并在 MutationObserver 选项中添加了 `attributeOldValue` 以获取先前的视频链接。

### 缩略图标签改进：

* `src/thumbnail-utils/thumbnails.ts`：增强了 `labelThumbnail`，使其接受一个可选的 `thumbnailOldHref` 参数，以帮助判断缩略图的视频 ID 是否发生变化。
* `src/thumbnail-utils/thumbnails.ts`：新增逻辑，当视频 ID 在更新后保持不变时，重用现有的缩略图标签。通过此逻辑可以避免更新 DOM 导致的无限循环问题。
* `src/thumbnail-utils/thumbnails.ts`：修复了选择器逻辑，应以ID而非类名的方式获取先前的`labelThumbnail`。