### PR TITLE
Fix title attribute in CategoryPillComponent

### DIFF
--- a/src/components/CategoryPillComponent.tsx
+++ b/src/components/CategoryPillComponent.tsx
@@ -48,6 +48,7 @@ class CategoryPillComponent extends React.Component<CategoryPillProps, CategoryP
                 style={style}
                 className={"sponsorBlockCategoryPill" + (!this.props.showTextByDefault ? " sbPillNoText" : "")}
                 aria-label={this.getTitleText()}
+                title=""
                 onClick={(e) => this.toggleOpen(e)}
                 onMouseEnter={() => this.openTooltip()}
                 onMouseLeave={() => this.closeTooltip()}


### PR DESCRIPTION
- [x] 我同意我的所有贡献将以GPL-3.0协议开源。

***
本次 Pull Request 主要是优化视频分类标签文字提示问题。通过禁用默认继承的视频标题 Title 防止与插件的 Tooltip 显示冲突。