### PR TITLE
Fixed lack of thumbnail update in t.bilibili.com

### DIFF
--- a/src/thumbnail-utils/thumbnail-selectors.ts
+++ b/src/thumbnail-utils/thumbnail-selectors.ts
@@ -57,7 +57,12 @@ const thumbnailSelectors: { [key: string]: ThumbnailSelector } = {
         thumbnailSelector: ".small-item",
     },
     "dynamic": {
-        // 动态页面
+        // 动态首页页面
+        containerSelector: "section:has(.bili-dyn-list)",
+        thumbnailSelector: ".bili-dyn-content",
+    },
+    "channelDynamic": {
+        // 用户空间动态
         containerSelector: ".bili-dyn-list",
         thumbnailSelector: ".bili-dyn-content",
     },
@@ -76,7 +81,7 @@ const pageTypeSepecialSelector: { [key in PageType]: string[] } = {
     [PageType.List]: ["listPlayerSideRecommendation", "listPlayerListCard"],
     [PageType.Search]: ["search"],
     [PageType.Dynamic]: ["dynamic"],
-    [PageType.Channel]: ["spaceMain", "spaceUpload", "dynamic"],
+    [PageType.Channel]: ["spaceMain", "spaceUpload", "channelDynamic"],
     [PageType.Message]: [],
     [PageType.Manga]: [],
     [PageType.Anime]: [],


### PR DESCRIPTION
- [x] 我同意我的所有贡献将以GPL-3.0协议开源。

***

本次 Pull Request 主要是对动态首页的不更新问题进行修复，以解决当前版本中，在[动态首页](https://t.bilibili.com)上方的筛选条切换UP主后，显示的视频不会被插件进行标记的问题。

