### PR TITLE
Update windowMessageListener

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -11,6 +11,26 @@ const sendMessageToContent = (messageData: InjectedScriptMessageSend, payload): 
         "/"
     );
 };
+let frameRate: number = 30;
+
+(function () {
+    const originalFetch = window.fetch;
+
+    window.fetch = async function (input, init) {
+        const url = typeof input === 'string' ? input : (input as Request).url;
+
+        const response = await originalFetch(input, init);
+        if (url.includes('/player/wbi/playurl') && url.includes(window.__INITIAL_STATE__.cid.toString())) {
+            response.clone().json().then(data => {
+                frameRate = data.data.dash.video
+                    .filter((v) => v.id === data.data.quality && v.codecid === data.data.video_codecid)[0]?.frameRate;
+            }).catch(() => {
+                frameRate = 30;
+            });
+        }
+        return response;
+    };
+})
 
 function windowMessageListener(message: MessageEvent) {
     const data: InjectedScriptMessageSend = message.data;
@@ -21,12 +41,9 @@ function windowMessageListener(message: MessageEvent) {
         if (data.type === "getBvID") {
             sendMessageToContent(data, window?.__INITIAL_STATE__?.bvid);
         } else if (data.type === "getFrameRate") {
-            const currentQuality = window?.__playinfo__?.data?.quality;
-            const frameRate = window?.__playinfo__?.data?.dash?.video.filter((v) => v.id === currentQuality)[0]
-                ?.frameRate;
             sendMessageToContent(data, frameRate);
         } else if (data.type === "getChannelID") {
-            sendMessageToContent(data, window?.__INITIAL_STATE__?.upInfo?.mid);
+            sendMessageToContent(data, window?.__INITIAL_STATE__?.upData?.mid);
         } else if (data.type === "getDescription") {
             sendMessageToContent(data, window?.__INITIAL_STATE__?.videoData?.desc);
         }

--- a/src/document.ts
+++ b/src/document.ts
@@ -30,7 +30,7 @@ let frameRate: number = 30;
         }
         return response;
     };
-})
+})();
 
 function windowMessageListener(message: MessageEvent) {
     const data: InjectedScriptMessageSend = message.data;

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -2,7 +2,6 @@ import SBObject from "./config";
 declare global {
     interface Window {
         SB: typeof SBObject;
-        __INITIAL_STATE__?: { bvid: string; upInfo: { mid: number }; videoData: { desc: string } };
-        __playinfo__?: { data: { quality: number; dash: { video: { id: number; frameRate: number }[] } } };
+        __INITIAL_STATE__?: { bvid: string; aid: number; cid: number; upData: { mid: string; }; videoData: { desc: string }};
     }
 }

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -2,6 +2,6 @@ import SBObject from "./config";
 declare global {
     interface Window {
         SB: typeof SBObject;
-        __INITIAL_STATE__?: { bvid: string; aid: number; cid: number; upData: { mid: string; }; videoData: { desc: string }};
+        __INITIAL_STATE__?: { bvid: string; aid: number; cid: number; upData: { mid: string }; videoData: { desc: string }};
     }
 }


### PR DESCRIPTION
- [X] 我同意我的所有贡献将以GPL-3.0协议开源。

***
阿B好像又在改东西了`__playinfo__`这个全局变量没了导致#96 现象出现  `__INITIAL_STATE__`也小改了一点
找了一圈没完全找到`__playinfo__`合并去哪了 就找到一个当前分辨率(`quality`)在`window.oldProfile.media.quality`出现了(可能原本就在这的)
其他的就没找到了(至少我没找到)
所以改用修改fetch方法抓取请求来获取视频帧率
***
其中
`v.codecid === data.data.video_codecid` 可加可不加 `video_codecid`这个貌似是服务器下发的自动选择的解码方式
如果手动选择了解码方式 帧率偏差在正负0.5左右 