### PR TITLE
Feat: Dynamic Sponsor Block

### DIFF
--- a/manifest/chrome-manifest-extra.json
+++ b/manifest/chrome-manifest-extra.json
@@ -22,7 +22,7 @@
       "matches": [
         "https://*.bilibili.com/*"
       ],
-      "all_frames": false,
+      "all_frames": true,
       "js": [
         "./js/content.js"
       ],
@@ -37,7 +37,7 @@
       "matches": [
         "https://*.bilibili.com/*"
       ],
-      "all_frames": false,
+      "all_frames": true,
       "js": [
         "./js/document.js"
       ]

--- a/manifest/firefox-manifest-extra.json
+++ b/manifest/firefox-manifest-extra.json
@@ -15,7 +15,7 @@
       "matches": [
         "https://*.bilibili.com/*"
       ],
-      "all_frames": false,
+      "all_frames": true,
       "js": [
         "./js/content.js"
       ],

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1237,5 +1237,65 @@
     },
     "bindPortVideo": {
         "message": "同步搬运视频"
+    },
+    "dynamicSponsorBlocker": {
+        "message": "隐藏动态主页的UP主贴片广告 (不包含视频)"
+    },
+    "dynamicSponsorBlockerDescription": {
+        "message": "贴片广告即动态内容包含推广内容的UP主动态"
+    },
+    "dynamicSpaceSponsorBlocker": {
+        "message": "隐藏UP主主页动态的广告"
+    },
+    "dynamicSpaceSponsorBlockerDescription": {
+        "message": "UP主主页动态的广告也会隐藏，不推荐开启，以方便查看UP主的完整动态"
+    },
+    "dynamicSponsorWhitelistedChannels": {
+        "message": "无视您的白名单"
+    },
+    "dynamicSponsorWhitelistedChannelsDescription": {
+        "message": "隐藏全部贴片广告，即使是您白名单中的UP主"
+    },
+    "dynamicSponsorShow": {
+        "message": "显示广告内容"
+    },
+    "dynamicSponsorHide": {
+        "message": "隐藏广告内容"
+    },
+    "dynamicSponsorRegexPattern": {
+        "message": "屏蔽匹配正则: "
+    },
+    "dynamicSponsorRegexPatternDescription": {
+        "message": "默认正则表达式偏保守，建议根据您关注的UP主动态内容自行修改(如果您会编写正则表达式)\n例如您关注的UP主们经常发某一个产品的广告，您可以将该产品的名称添加到正则表达式中"
+    },
+    "category_dynamicSponsor_sponsor": {
+        "message": "广告"
+    },
+    "category_dynamicSponsor_sponsor_description": {
+        "message": "即包含商品链接的UP主动态，目前阶段无法完全屏蔽，因为部分软广可能不附带链接或链接在评论区"
+    },
+    "category_dynamicSponsor_forward_sponsor": {
+        "message": "转发广告"
+    },
+    "category_dynamicSponsor_forward_sponsor_description": {
+        "message": "当转发动态是包含商品链接的UP主动态时，该动态会被视为转发广告"
+    },
+    "category_dynamicSponsor_suspicion_sponsor":{
+        "message": "疑似广告"
+    },
+    "category_dynamicSponsor_suspicion_sponsor_description": {
+        "message": "使用正则表达式对动态内容进行匹配来额外屏蔽软广动态，是对“ 广告 ”的补充，可能会误屏蔽或漏屏蔽部分动态"
+    },
+    "showOverlay_DynamicSponsor":{
+        "message": "仅显示标签"
+    },
+    "Hide_DynamicSponsor":{
+        "message": "隐藏内容"
+    },
+    "skipOptionDynamicSponsor":{
+        "message": "选项"
+    },
+    "colorDynamicSponsor":{
+        "message": "标签颜色"
     }
 }

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -1237,5 +1237,65 @@
     },
     "bindPortVideo": {
         "message": "同步搬运视频"
+    },
+    "dynamicSponsorBlocker": {
+        "message": "隐藏动态主页的UP主贴片广告 (不包含视频)"
+    },
+    "dynamicSponsorBlockerDescription": {
+        "message": "贴片广告即动态内容包含推广内容的UP主动态"
+    },
+    "dynamicSpaceSponsorBlocker": {
+        "message": "隐藏UP主主页动态的广告"
+    },
+    "dynamicSpaceSponsorBlockerDescription": {
+        "message": "UP主主页动态的广告也会隐藏，不推荐开启，以方便查看UP主的完整动态"
+    },
+    "dynamicSponsorWhitelistedChannels": {
+        "message": "无视您的白名单"
+    },
+    "dynamicSponsorWhitelistedChannelsDescription": {
+        "message": "隐藏全部贴片广告，即使是您白名单中的UP主"
+    },
+    "dynamicSponsorShow": {
+        "message": "显示广告内容"
+    },
+    "dynamicSponsorHide": {
+        "message": "隐藏广告内容"
+    },
+    "dynamicSponsorRegexPattern": {
+        "message": "屏蔽匹配正则: "
+    },
+    "dynamicSponsorRegexPatternDescription": {
+        "message": "默认正则表达式偏保守，建议根据您关注的UP主动态内容自行修改(如果您会编写正则表达式)\n例如您关注的UP主们经常发某一个产品的广告，您可以将该产品的名称添加到正则表达式中"
+    },
+    "category_dynamicSponsor_sponsor": {
+        "message": "广告"
+    },
+    "category_dynamicSponsor_sponsor_description": {
+        "message": "即包含商品链接的UP主动态，目前阶段无法完全屏蔽，因为部分软广可能不附带链接或链接在评论区"
+    },
+    "category_dynamicSponsor_forward_sponsor": {
+        "message": "转发广告"
+    },
+    "category_dynamicSponsor_forward_sponsor_description": {
+        "message": "当转发动态是包含商品链接的UP主动态时，该动态会被视为转发广告"
+    },
+    "category_dynamicSponsor_suspicion_sponsor":{
+        "message": "疑似广告"
+    },
+    "category_dynamicSponsor_suspicion_sponsor_description": {
+        "message": "使用正则表达式对动态内容进行匹配来额外屏蔽软广动态，是对“ 广告 ”的补充，可能会误屏蔽或漏屏蔽部分动态"
+    },
+    "showOverlay_DynamicSponsor":{
+        "message": "仅显示标签"
+    },
+    "Hide_DynamicSponsor":{
+        "message": "隐藏内容"
+    },
+    "skipOptionDynamicSponsor":{
+        "message": "选项"
+    },
+    "colorDynamicSponsor":{
+        "message": "标签颜色"
     }
 }

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -1237,5 +1237,65 @@
     },
     "bindPortVideo": {
         "message": "同步搬運影片"
+    },
+    "dynamicSponsorBlocker": {
+        "message": "隱藏動態主頁的UP主貼片廣告 (不包含視頻)"
+    },
+    "dynamicSponsorBlockerDescription": {
+        "message": "貼片廣告即動態內容包含推廣內容的UP主動態"
+    },
+    "dynamicSpaceSponsorBlocker": {
+        "message": "隱藏UP主主頁動態的廣告"
+    },
+    "dynamicSpaceSponsorBlockerDescription": {
+        "message": "UP主主頁動態的廣告也會隱藏，不推薦開啟，以方便查看UP主的完整動態"
+    },
+    "dynamicSponsorWhitelistedChannels": {
+        "message": "無視您的白名單"
+    },
+    "dynamicSponsorWhitelistedChannelsDescription": {
+        "message": "隱藏全部貼片廣告，即使是您白名單中的UP主"
+    },
+    "dynamicSponsorShow": {
+        "message": "顯示廣告內容"
+    },
+    "dynamicSponsorHide": {
+        "message": "隱藏廣告內容"
+    },
+    "dynamicSponsorRegexPattern": {
+        "message": "屏蔽匹配正則: "
+    },
+    "dynamicSponsorRegexPatternDescription": {
+        "message": "默認正則表達式偏保守，建議根據您關注的UP主動態內容自行修改(如果您會編寫正則表達式)\n例如您關注的UP主們經常發某一個產品的廣告，您可以將該產品的名稱添加到正則表達式中"
+    },
+    "category_dynamicSponsor_sponsor": {
+        "message": "廣告"
+    },
+    "category_dynamicSponsor_sponsor_description": {
+        "message": "即包含商品鏈接的UP主動態，目前階段無法完全屏蔽，因為部分軟廣可能不附帶鏈接或鏈接在評論區"
+    },
+    "category_dynamicSponsor_forward_sponsor": {
+        "message": "轉發廣告"
+    },
+    "category_dynamicSponsor_forward_sponsor_description": {
+        "message": "當轉發動態是包含商品鏈接的UP主動態時，該動態會被視為轉發廣告"
+    },
+    "category_dynamicSponsor_suspicion_sponsor": {
+        "message": "疑似廣告"
+    },
+    "category_dynamicSponsor_suspicion_sponsor_description": {
+        "message": "使用正則表達式對動態內容進行匹配來額外屏蔽軟廣動態，是對“ 廣告 ”的補充，可能會誤屏蔽或漏屏蔽部分動態"
+    },
+    "showOverlay_DynamicSponsor": {
+        "message": "僅顯示標籤"
+    },
+    "Hide_DynamicSponsor": {
+        "message": "隱藏內容"
+    },
+    "skipOptionDynamicSponsor": {
+        "message": "選項"
+    },
+    "colorDynamicSponsor": {
+        "message": "標籤顏色"
     }
 }

--- a/public/content.css
+++ b/public/content.css
@@ -931,3 +931,41 @@ input::-webkit-inner-spin-button {
 .youtube-logo-triangle.expanded {
 	transform: rotate(90deg);
 }
+
+/*bilibili Dynamic sponsor label */
+#dynamicSponsorLabel {
+	display: flex;
+	background-color: var(--category-color, #fff);
+	border-radius: 2em;
+	padding: 0.4em;
+	margin: 0.4em;
+    align-items: center;
+	transition: border-radius 0.4s 0.05s;
+}
+
+#dynamicSponsorLabel svg {
+	width: 1.5em;
+	height: 1.5em;
+	fill: var(--category-text-color, #fff);
+}
+
+#dynamicSponsorLabel span {
+	display: none;
+	padding-left: 0.25em;
+    font-size: 1.2em;
+    color: var(--category-text-color, #fff);
+}
+
+#showDynamicSponsor {
+    color: var(--text2);
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    padding: 0;
+}
+
+#showDynamicSponsor svg {
+	height: 1.2em;
+	width: 1.2em;
+    fill: var(--text2);
+}

--- a/public/options/options.html
+++ b/public/options/options.html
@@ -49,6 +49,62 @@
 			<div id="behavior" class="option-group hidden">
 				<div id="category-type" data-type="react-CategoryChooserComponent"></div>
 
+				<div data-type="toggle" data-sync="dynamicSponsorBlocker">
+					<div class="switch-container">
+						<label class="switch">
+							<input id="dynamicSponsorBlocker" type="checkbox" checked>
+							<span class="slider round"></span>
+						</label>
+						<label class="switch-label" for="dynamicSponsorBlocker">
+							__MSG_dynamicSponsorBlocker__
+						</label>
+					</div>
+					<div class="small-description">__MSG_dynamicSponsorBlockerDescription__</div>
+
+					<div data-type="toggle" data-dependent-on="dynamicSponsorBlocker">
+						<br />
+						<div id="DynamicSponsor" data-type="react-DynamicSponsorChooserComponent"></div>
+
+						<div data-type="text-change" data-sync="dynamicSponsorRegexPattern">
+							<div class="input-container">
+								<label for="dynamicSponsorRegexPattern">__MSG_dynamicSponsorRegexPattern__</label>
+								<input id="dynamicSponsorRegexPattern" class="option-text-box" type="text" />
+								<button class="text-change-set">__MSG_save__</button>
+								<button class="text-change-reset">__MSG_reset__</button>
+							</div>
+								<div class="small-description">__MSG_dynamicSponsorRegexPatternDescription__</div>
+						</div>
+
+						<div data-type="toggle" data-sync="dynamicSpaceSponsorBlocker">
+							<br />
+							<div class="switch-container">
+								<label class="switch">
+									<input id="dynamicSpaceSponsorBlocker" type="checkbox" checked>
+									<span class="slider round"></span>
+								</label>
+								<label class="switch-label" for="dynamicSpaceSponsorBlocker">
+									__MSG_dynamicSpaceSponsorBlocker__
+								</label>
+							</div>
+							<div class="small-description">__MSG_dynamicSpaceSponsorBlockerDescription__</div>
+						</div>
+
+						<div data-type="toggle" data-sync="dynamicSponsorWhitelistedChannels">
+							<br />
+							<div class="switch-container">
+								<label class="switch">
+									<input id="dynamicSponsorWhitelistedChannels" type="checkbox" checked>
+									<span class="slider round"></span>
+								</label>
+								<label class="switch-label" for="dynamicSponsorWhitelistedChannels">
+									__MSG_dynamicSponsorWhitelistedChannels__
+								</label>
+							</div>
+							<div class="small-description">__MSG_dynamicSponsorWhitelistedChannelsDescription__</div>
+						</div>
+					</div>
+				</div>
+
 				<div data-type="toggle" data-sync="muteSegments">
 					<div class="switch-container">
 						<label class="switch">

--- a/src/components/options/CategoryChooserComponent.tsx
+++ b/src/components/options/CategoryChooserComponent.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import * as CompileConfig from "../../../config.json";
 import { Category } from "../../types";
-import CategorySkipOptionsComponent from "./CategorySkipOptionsComponent";
+import {CategorySkipOptionsComponent, DynamicSponsorHideOptionsComponent} from "./CategorySkipOptionsComponent";
 
 export interface CategoryChooserProps {}
 
@@ -59,4 +59,54 @@ class CategoryChooserComponent extends React.Component<CategoryChooserProps, Cat
     }
 }
 
-export default CategoryChooserComponent;
+class DynamicSponsorChooserComponent extends React.Component<CategoryChooserProps, CategoryChooserState> {
+    constructor(props: CategoryChooserProps) {
+        super(props);
+
+        // Setup state
+        this.state = {};
+    }
+
+    render(): React.ReactElement {
+        return (
+            <table id="categoryChooserTable" className="categoryChooserTable">
+                <tbody>
+                    <tr id={"CategoryOptionsRow"} className="categoryTableElement categoryTableHeader">
+                        <th id={"CategoryOptionName"}>
+                            {chrome.i18n.getMessage("category")}
+                        </th>
+
+                        <th id={"CategoryHideOption"} className="HideOption">
+                            {chrome.i18n.getMessage("skipOptionDynamicSponsor")}
+                        </th>
+                        
+                        <th id={"CategoryColorOption"} className="ColorOption">
+                            {chrome.i18n.getMessage("colorDynamicSponsor")}
+                        </th>
+                    </tr>
+
+
+                    {this.getCategorySkipOptions()}
+                </tbody>
+            </table>
+        );
+    }
+
+    getCategorySkipOptions(): JSX.Element[] {
+        const elements: JSX.Element[] = [];
+        const list = ["dynamicSponsor_sponsor", "dynamicSponsor_forward_sponsor", "dynamicSponsor_suspicion_sponsor"]
+
+        for (const category of list) {
+            elements.push(
+                <DynamicSponsorHideOptionsComponent
+                    category={category as Category}
+                    key={category}
+                ></DynamicSponsorHideOptionsComponent>
+            );
+        }
+
+        return elements;
+    }
+}
+
+export {CategoryChooserComponent, DynamicSponsorChooserComponent}

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,8 @@ import {
     SponsorTime,
     VideoID,
     SponsorHideType,
+    DynamicSponsorSelection,
+    DynamicSponsorOption,
 } from "./types";
 import { Keybind, ProtoConfig, keybindEquals } from "./config/config";
 import { HashedValue } from "./utils/hash";
@@ -90,6 +92,11 @@ interface SBConfig {
     showPortVideoButton: boolean;
     cleanPopup: boolean;
 
+    dynamicSponsorWhitelistedChannels: boolean;
+    dynamicSponsorBlocker: boolean;
+    dynamicSpaceSponsorBlocker: boolean;
+    dynamicSponsorRegexPattern: string;
+
     showNewIcon: boolean;
 
     // Used to cache calculated text color info
@@ -143,6 +150,15 @@ interface SBConfig {
         "preview-poi_highlight": PreviewBarOption;
         "filler": PreviewBarOption;
         "preview-filler": PreviewBarOption;
+    };
+
+    
+    //动态主页UP主贴片广告
+    dynamicSponsorSelections: DynamicSponsorSelection[];
+    dynamicSponsorTypes: {
+        "dynamicSponsor_sponsor": PreviewBarOption;
+        "dynamicSponsor_forward_sponsor": PreviewBarOption;
+        "dynamicSponsor_suspicion_sponsor": PreviewBarOption;
     };
 }
 
@@ -279,6 +295,11 @@ const syncDefaults = {
     showPortVideoButton: true,
     cleanPopup: false,
 
+    dynamicSponsorWhitelistedChannels: false,
+    dynamicSponsorBlocker: false,
+    dynamicSpaceSponsorBlocker: false,
+    dynamicSponsorRegexPattern: "(618|11(?!1).11|双(11|十一|12|十二))|恰(?:个|了|到)?饭|((领(?:取)?|抢|有)(?:神|优惠)?券|券后)|(淘宝|京东|拼多多)搜索|(点(?:击)|戳|来|我)评论区(?:置顶)|(立即|蓝链)(?:购买|下单)|满\\d+|(大促|促销)|折扣|特价|秒杀|广告|低至|热卖|抢购|新品|豪礼|赠品",
+    
     showNewIcon: true,
 
     categoryPillColors: {},
@@ -436,6 +457,36 @@ const syncDefaults = {
             opacity: "0.7",
         },
     },
+
+    //动态主页UP主贴片广告
+    dynamicSponsorSelections: [
+        {
+            name: "dynamicSponsor_sponsor" as Category,
+            option: DynamicSponsorOption.Hide,
+        },
+        {
+            name: "dynamicSponsor_forward_sponsor" as Category,
+            option: DynamicSponsorOption.Hide,
+        },
+        {
+            name: "dynamicSponsor_suspicion_sponsor" as Category,
+            option: DynamicSponsorOption.Disabled,
+        },
+    ],
+    dynamicSponsorTypes: {
+        dynamicSponsor_sponsor: {
+            color: "#007800",
+            opacity: "0.7",
+        },
+        dynamicSponsor_forward_sponsor: {
+            color: "#bfbf35",
+            opacity: "0.7",
+        },
+        dynamicSponsor_suspicion_sponsor: {
+            color: "#a6634a",
+            opacity: "0.7",
+        },
+    }
 };
 
 const localDefaults = {

--- a/src/content.ts
+++ b/src/content.ts
@@ -66,6 +66,7 @@ import {
     updateFrameRate,
 } from "./utils/video";
 import { openWarningDialog } from "./utils/warnings";
+import { DynamicListener } from "./render/DynamicSponsorBlock"
 
 cleanPage();
 
@@ -73,6 +74,11 @@ const utils = new Utils();
 
 waitFor(() => Config.isReady(), 5000, 10).then(() => {
     setCategoryColorCSSVariables();
+
+    if ((window.location.href.includes("t.bilibili.com") ||
+        window.location.href.includes("space.bilibili.com")) &&
+        Config.config.dynamicSponsorBlocker
+    ) DynamicListener();
 });
 
 detectPageType();
@@ -2884,7 +2890,7 @@ function setCategoryColorCSSVariables() {
     }
 
     let css = ":root {";
-    for (const [category, config] of Object.entries(Config.config.barTypes)) {
+    for (const [category, config] of Object.entries(Config.config.barTypes).concat(Object.entries(Config.config.dynamicSponsorTypes))) {
         css += `--sb-category-${category}: ${config.color};`;
         css += `--darkreader-bg--sb-category-${category}: ${config.color};`;
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -10,7 +10,7 @@ window.SB = Config;
 import KeybindComponent from "./components/options/KeybindComponent";
 import { StorageChangesObject } from "./config/config";
 import { showDonationLink } from "./config/configUtils";
-import CategoryChooser from "./render/CategoryChooser";
+import { CategoryChooser, DynamicSponsorChooser} from "./render/CategoryChooser";
 import { setMessageNotice, showMessage } from "./render/MessageNotice";
 import UnsubmittedVideos from "./render/UnsubmittedVideos";
 import { asyncRequestToServer } from "./requests/requests";
@@ -309,6 +309,9 @@ async function init() {
                 break;
             case "react-UnsubmittedVideosComponent":
                 unsubmittedVideos.push(new UnsubmittedVideos(optionsElements[i]));
+                break;
+            case "react-DynamicSponsorChooserComponent":
+                categoryChoosers.push(new DynamicSponsorChooser(optionsElements[i]));
                 break;
         }
     }

--- a/src/render/CategoryChooser.tsx
+++ b/src/render/CategoryChooser.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { createRoot } from "react-dom/client";
 
-import CategoryChooserComponent from "../components/options/CategoryChooserComponent";
+import { CategoryChooserComponent, DynamicSponsorChooserComponent } from "../components/options/CategoryChooserComponent";
 
 class CategoryChooser {
     ref: React.RefObject<CategoryChooserComponent>;
@@ -18,4 +18,19 @@ class CategoryChooser {
     }
 }
 
-export default CategoryChooser;
+class DynamicSponsorChooser {
+    ref: React.RefObject<DynamicSponsorChooserComponent>;
+
+    constructor(element: Element) {
+        this.ref = React.createRef();
+
+        const root = createRoot(element);
+        root.render(<DynamicSponsorChooserComponent ref={this.ref} />);
+    }
+
+    update(): void {
+        this.ref.current?.forceUpdate();
+    }
+}
+
+export {CategoryChooser, DynamicSponsorChooser};

--- a/src/render/DynamicSponsorBlock.tsx
+++ b/src/render/DynamicSponsorBlock.tsx
@@ -1,0 +1,164 @@
+import Config from "../config";
+import { waitFor, sleep } from "../utils/";
+import { DynamicSponsorOption, DynamicSponsorSelection } from "../types";
+
+export { DynamicListener };
+
+async function DynamicListener() {
+    const observer = new MutationObserver(async (mutationList) => {
+        await sleep(100);
+
+        for (const mutation of mutationList) {
+            const element = mutation.addedNodes[0] as HTMLElement;
+            const category = isSponsor(element);
+            const action = getCategorySelection(category)?.option
+            if (category === null || action === DynamicSponsorOption.Disabled) continue;
+
+            const upId = element.querySelector('.bili-dyn-item__avatar').getAttribute('bilisponsor-userid');
+            const upIdOrigin = element?.querySelector('.dyn-orig-author__face')?.getAttribute('bilisponsor-userid');
+            if ((!(Config.config.whitelistedChannels.includes(upId) ||
+                Config.config.whitelistedChannels?.includes(upIdOrigin)) ||
+                Config.config.dynamicSponsorWhitelistedChannels) &&
+                !(!Config.config.dynamicSpaceSponsorBlocker &&
+                window.location.href.includes("space.bilibili.com")) &&
+                action === DynamicSponsorOption.Hide
+            ) {
+                const bodyElement = element.querySelector('.bili-dyn-content') as HTMLElement;
+                bodyElement.style.display = 'none';
+
+                const toggleButton = getButton();
+                toggleButton.textContent = chrome.i18n.getMessage('dynamicSponsorShow');
+                toggleButton.insertBefore(getIcon(), toggleButton.firstChild);
+                toggleButton.addEventListener('click', () => {
+                    const isHidden = bodyElement.style.display === 'none' || !bodyElement.style.height === null;
+
+                    if (isHidden) {
+                        bodyElement.style.display = 'block';
+                        bodyElement.style.overflow = 'hidden';
+                        bodyElement.style.height = '0px';
+                        bodyElement.offsetHeight;
+
+                        const targetHeight = bodyElement.scrollHeight;
+                        bodyElement.style.transition = 'height 0.5s ease-in-out';
+                        bodyElement.style.height = `${targetHeight}px`;
+                    } else {
+                        const targetHeight = bodyElement.scrollHeight;
+                        bodyElement.style.height = `${targetHeight}px`;
+                        bodyElement.offsetHeight;
+
+                        bodyElement.style.transition = 'height 0.5s ease-in-out';
+                        bodyElement.style.height = '0px';
+                    }
+                    bodyElement.addEventListener('transitionend', () => {
+                        if (isHidden) {
+                            bodyElement.style.height = '';
+                        } else {
+                            bodyElement.style.display = 'none';
+                            bodyElement.style.height = '';
+                        }
+                    }, { once: true });
+
+                    toggleButton.textContent = chrome.i18n.getMessage(isHidden ? 'dynamicSponsorHide' : 'dynamicSponsorShow');
+                    toggleButton.insertBefore(getIcon(), toggleButton.firstChild);
+                });
+                element.querySelector('.bili-dyn-item__footer').appendChild(toggleButton);
+            }
+            const dynamicSponsor = document.createElement('div');
+            dynamicSponsor.id = 'dynamicSponsorLabel';
+            dynamicSponsor.appendChild(getIcon());
+
+            const dynamicSponsorText = document.createElement('span');
+            dynamicSponsorText.textContent = chrome.i18n.getMessage(`category_${category}`);
+            dynamicSponsor.style.setProperty(
+                "--category-color",
+                `var(--sb-category-${category})`
+            );
+            dynamicSponsor.style.setProperty(
+                "--category-text-color",
+                `var(--sb-category-text-${category})`
+            );
+            dynamicSponsor.appendChild(dynamicSponsorText);
+            dynamicSponsor.addEventListener('mouseenter', () => {
+                dynamicSponsorText.style.display = 'block';
+                dynamicSponsor.style.borderRadius = '0.5em';
+            });
+            dynamicSponsor.addEventListener('mouseleave', () => {
+                dynamicSponsorText.style.display = 'none';
+                dynamicSponsor.style.borderRadius = '2em';
+            });
+
+            element.querySelector('.bili-dyn-title').appendChild(dynamicSponsor);
+
+            await sleep(100);
+        }
+    });
+
+    observer.observe(await getElementWaitFor(".bili-dyn-list__items"), {
+        attributeFilter: ['class'],
+        childList: true
+    });
+
+    (await getElementWaitFor(".bili-dyn-up-list__content, .nav-bar__main-left")).addEventListener("click", async () => {
+        observer.disconnect();
+
+        observer.observe(await getElementWaitFor(".bili-dyn-list__items"), {
+            attributeFilter: ['class'],
+            childList: true,
+        });
+    });
+}
+
+async function getElementWaitFor(element: string) {
+    return await waitFor(
+        () => document.querySelector(element) as HTMLElement,
+        5000,
+        50
+    );
+}
+
+function getCategorySelection(category: string): DynamicSponsorSelection {
+    for (const selection of Config.config.dynamicSponsorSelections) {
+        if (selection.name === category) {
+            return selection;
+        }
+    }
+    return { name: category, option: DynamicSponsorOption.Disabled } as DynamicSponsorSelection;
+}
+
+function isSponsor(element: HTMLElement) {
+    const pattern = new RegExp(Config.config.dynamicSponsorRegexPattern);
+    const goodsElement = element?.querySelector('.bili-dyn-card-goods');
+    const goodsElementOrigin = element?.querySelector('.bili-dyn-card-goods.hide-border');
+    if (goodsElementOrigin) {
+        return "dynamicSponsor_forward_sponsor";
+    } else if (goodsElement) {
+        return "dynamicSponsor_sponsor";
+    }
+
+    let goodsOnText = false
+    const contentDiv = element?.querySelectorAll('.bili-rich-text__content span:not(.bili-dyn-item__interaction *)');
+    if (!contentDiv) return null;
+
+    let combinedText = '';
+    contentDiv.forEach(span => {
+        combinedText += span.textContent;
+    });
+    goodsOnText = pattern.test(combinedText);
+    return goodsOnText ? "dynamicSponsor_suspicion_sponsor" : null;
+}
+
+function getIcon() {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("viewBox", "0 0 568 568");
+    const use = document.createElementNS("http://www.w3.org/2000/svg", "use");
+    use.setAttribute("href", "#SponsorBlockIcon");
+    svg.appendChild(use);
+    return svg;
+}
+
+function getButton() {
+    const toggleButton = document.createElement('button');
+    toggleButton.id = 'showDynamicSponsor';
+    toggleButton.className = 'bili-dyn-action';
+    return toggleButton;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,17 @@ export interface CategorySelection {
     option: CategorySkipOption;
 }
 
+export enum DynamicSponsorOption {
+    Disabled,
+    ShowOverlay,
+    Hide,
+}
+
+export interface DynamicSponsorSelection {
+    name: Category;
+    option: DynamicSponsorOption;
+}
+
 export enum SponsorHideType {
     Visible = undefined,
     Downvoted = 1,


### PR DESCRIPTION
- [X] 我同意我的所有贡献将以GPL-3.0协议开源。

***
支持隐藏动态中的UP主文字推广动态 
( 写完才发现感觉没啥用 不会有哪位UP主天天发推广动态吧  如果觉得没用直接把这个pr close就行)

支持三种类别及白名单
- `广告`: 直接带有商品链接的动态
- `转发广告`: 转发一个带有商品链接的动态
- `疑似广告`: 使用正则表达式对动态内容匹配上的动态

以及是否仅显示类别不隐藏动态内容
***
### 新增权限
`all_frames`: 这个是为了支持[BewlyBewly](https://github.com/BewlyBewly/BewlyBewly)的动态主页 它把动态主页用 iframe 嵌入网页中
![image](https://github.com/user-attachments/assets/9e83684d-be94-4cbb-a07f-483f3b43e895)
***
### 效果预览
https://github.com/user-attachments/assets/88b58f6d-b039-4833-8d90-73773ee25d20