### PR TITLE
Modify description

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -623,11 +623,11 @@
         "message": "仅用于标记整部视频。用于视频展示创作者体验的产品、服务或地点。包括抢先体验、独家拥有等。"
     },
     "category_exclusive_access_pill": {
-        "message": "此视频展示了UP主免费或获得后补贴使用的产品或者服务，包括软广、产品推广或者品牌推广",
+        "message": "此视频展示了创作者独家拥有的产品、服务或地点",
         "description": "此类别的简短描述"
     },
     "category_exclusive_access_guideline1": {
-        "message": "整个视频都在展示免费或获得补贴后使用的内容"
+        "message": "整个视频都在展示抢先体验、独家拥有的内容"
     },
     "category_interaction": {
         "message": "三连/订阅提醒"

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -617,10 +617,10 @@
         "message": "不是公司设计的产品和周边"
     },
     "category_exclusive_access": {
-        "message": "柔性推广/品牌合作"
+        "message": "独家限定"
     },
     "category_exclusive_access_description": {
-        "message": "仅用于对整个视频进行标记。适用于展示UP主免费或获得补贴后使用的产品、服务或场地的视频。"
+        "message": "仅用于标记整部视频。用于视频展示创作者体验的产品、服务或地点。包括抢先体验、独家拥有等。"
     },
     "category_exclusive_access_pill": {
         "message": "此视频展示了UP主免费或获得后补贴使用的产品或者服务，包括软广、产品推广或者品牌推广",

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -623,11 +623,11 @@
         "message": "仅用于标记整部视频。用于视频展示创作者体验的产品、服务或地点。包括抢先体验、独家拥有等。"
     },
     "category_exclusive_access_pill": {
-        "message": "此视频展示了UP主免费或获得后补贴使用的产品或者服务，包括软广、产品推广或者品牌推广",
+        "message": "此视频展示了创作者独家拥有的产品、服务或地点",
         "description": "此类别的简短描述"
     },
     "category_exclusive_access_guideline1": {
-        "message": "整个视频都在展示免费或获得补贴后使用的内容"
+        "message": "整个视频都在展示抢先体验、独家拥有的内容"
     },
     "category_interaction": {
         "message": "三连/订阅提醒"

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -617,10 +617,10 @@
         "message": "不是公司设计的产品和周边"
     },
     "category_exclusive_access": {
-        "message": "柔性推广/品牌合作"
+        "message": "独家限定"
     },
     "category_exclusive_access_description": {
-        "message": "仅用于对整个视频进行标记。适用于展示UP主免费或获得补贴后使用的产品、服务或场地的视频。"
+        "message": "仅用于标记整部视频。用于视频展示创作者体验的产品、服务或地点。包括抢先体验、独家拥有等。"
     },
     "category_exclusive_access_pill": {
         "message": "此视频展示了UP主免费或获得后补贴使用的产品或者服务，包括软广、产品推广或者品牌推广",

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -617,10 +617,10 @@
         "message": "不是公司設計的產品和周邊"
     },
     "category_exclusive_access": {
-        "message": "柔性推廣/品牌合作"
+        "message": "獨家限定"
     },
     "category_exclusive_access_description": {
-        "message": "僅用於標記整個影片。適用於影片展示創作者免費或獲得補助使用的產品或者服務，包括軟廣、產品推廣或者品牌推廣。"
+        "message": "僅用於標記整部影片。用於影片展示創作者體驗的產品、服務或地點。包括搶先體驗、獨家擁有等。"
     },
     "category_exclusive_access_pill": {
         "message": "此影片展示了創作者免費或獲得補助使用的產品、服務或場地",

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -623,11 +623,11 @@
         "message": "僅用於標記整部影片。用於影片展示創作者體驗的產品、服務或地點。包括搶先體驗、獨家擁有等。"
     },
     "category_exclusive_access_pill": {
-        "message": "此影片展示了創作者免費或獲得補助使用的產品、服務或場地",
+        "message": "此影片展示了創作者獨家擁有的產品、服務或地點",
         "description": "此類別的簡短描述"
     },
     "category_exclusive_access_guideline1": {
-        "message": "整個影片都在展示免費或獲得補助使用的內容"
+        "message": "整個影片都在展示搶先體驗、獨家擁有的內容"
     },
     "category_interaction": {
         "message": "三連/訂閱提醒"


### PR DESCRIPTION
老實說自從改了這個之後 出現越來越多人錯標的問題 另外我覺得拔掉原本的獨家限定實在不太好 儘管這是個小眾分類 但是也有存在的必要 像是最近的5090搶先評測就適用這個分類 又或者是某款3A遊戲的試玩(非商單的部分) 其實[wiki](https://wiki.sponsor.ajay.app/w/Full_Video_Labels#Exclusive_Access )上都已經明確定義他的分類了 廣告實在沒必要區分是什麼類型的廣告 現在的定義是這樣的

- 柔性推广/品牌合作
仅用于对整个视频进行标记。适用于展示UP主免费或获得补贴后使用的产品、服务或场地的视频。
此视频展示了UP主免费或获得后补贴使用的产品或者服务，包括软广、产品推广或者品牌推广

首先談談柔性推廣的部分 我覺得這其實就跟原本的無償推廣的分類界限有點模糊 我是不知道b站上面有什麼所謂的柔性推廣 一般要馬廣告要馬無償推廣
其次所謂的品牌合作說白了就是廣告 應該說有哪個廣告不是跟品牌有合作的 正常就應該直接分進廣告類
