### PR TITLE
在 CategoryPill 的 Tooltip 中添加投票提示

### DIFF
--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -1301,5 +1301,8 @@
     },
     "dynamicSponsorBlockerDebugDescription":{
         "message": "把鼠标悬浮到标签时显示匹配到的文字"
+    },
+    "requestVote": {
+        "message": "片段标记准确吗？"
     }
 }

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -1301,5 +1301,8 @@
     },
     "dynamicSponsorBlockerDebugDescription": {
         "message": "把鼠標懸浮到標籤時顯示匹配到的文字"
+    },
+    "requestVote": {
+        "message": "片段標記準確嗎？"
     }
 }

--- a/public/content.css
+++ b/public/content.css
@@ -686,6 +686,10 @@ input::-webkit-inner-spin-button {
 	display: none !important;
 }
 
+.sponsorBlockTooltipContainer {
+	z-index: 10;
+}
+
 .sponsorBlockTooltip {
 	position: absolute;
 	background-color: rgba(28, 28, 28, 0.7);

--- a/public/content.css
+++ b/public/content.css
@@ -1011,3 +1011,18 @@ input::-webkit-inner-spin-button {
 	width: 1.2em;
     fill: var(--text2);
 }
+.voteRequestContainer {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 4px;
+	opacity: 0.8;
+}
+
+.voteRequestContainer .voteButton {
+	border: white 1px solid;
+	border-radius: 32px;
+	padding: 4px 6px;
+	display: flex;
+	gap: 4px;
+}

--- a/src/components/CategoryPillComponent.tsx
+++ b/src/components/CategoryPillComponent.tsx
@@ -36,19 +36,43 @@ class CategoryPillComponent extends React.Component<CategoryPillProps, CategoryP
             open: false,
         };
 
-        waitFor(() => document.querySelector("#viewbox_report").childNodes[1], 10000).then(() => {
-            const tooltipMount = document.querySelector("#viewbox_report") as HTMLElement;
-            this.tooltip = new PersistedTooltip({
-                text: this.getTitleText(),
-                referenceNode: tooltipMount,
-                bottomOffset: "unset",
-                topOffset: "4px",
-                opacity: 0.95,
-                displayTriangle: false,
-                showLogo: false,
-                showGotIt: false,
-                prependElement: tooltipMount.childNodes[1] as HTMLElement,
-            });
+        waitFor(() => document.querySelector("#viewbox_report").childNodes[1], 10000)
+            .then(() => {
+                const tooltipMount = document.querySelector("#viewbox_report") as HTMLElement;
+                this.tooltip = new PersistedTooltip({
+                    text: this.getTitleText(),
+                    referenceNode: tooltipMount,
+                    bottomOffset: "unset",
+                    topOffset: "4px",
+                    opacity: 0.95,
+                    displayTriangle: false,
+                    showLogo: false,
+                    showGotIt: false,
+                    prependElement: tooltipMount.childNodes[1] as HTMLElement,
+                    elements: [
+                        <>
+                            <div className="voteRequestContainer sponsorSkipObject">
+                                <span>{chrome.i18n.getMessage("requestVote")}</span>
+                                <div
+                                    className="voteButton"
+                                    title={chrome.i18n.getMessage("upvote")}
+                                    onClick={(e) => this.vote(e, 1)}
+                                >
+                                    <ThumbsUpSvg fill={Config.config.colorPalette.white} />
+                                    <span>{chrome.i18n.getMessage("upvote")}</span>
+                                </div>
+                                <div
+                                    className="voteButton"
+                                    title={chrome.i18n.getMessage("reportButtonInfo")}
+                                    onClick={(e) => this.vote(e, 0)}
+                                >
+                                    <ThumbsDownSvg fill={downvoteButtonColor(null, null, SkipNoticeAction.Downvote)} />
+                                    <span>{chrome.i18n.getMessage("downvote")}</span>
+                                </div>
+                            </div>
+                        </>,
+                    ],
+                });
             })
             .catch(() => {
                 console.warn("等待查找category tooltip 挂载点时超时");

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -114,7 +114,6 @@ export class GenericTooltip {
                     style={{
                         marginBottom: props.innerBottomMargin,
                         maxHeight: props.textBoxMaxHeight,
-                        overflowY: "auto",
                     }}
                 >
                     {props.showLogo ? (

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -65,6 +65,7 @@ export class GenericTooltip {
 
         this.container = document.createElement("div");
         this.container.id = "sponsorTooltip" + props.text;
+        this.container.classList.add("sponsorBlockTooltipContainer");
         if (props.positionRealtive) this.container.style.position = "relative";
         if (props.containerAbsolute) this.container.style.position = "absolute";
         if (props.center) {
@@ -99,13 +100,15 @@ export class GenericTooltip {
                     backgroundColor,
                     margin: props.center ? "auto" : undefined,
                 }}
-                className={
-                    "sponsorBlockTooltip" +
-                    (props.displayTriangle || props.topTriangle ? " sbTriangle" : "") +
-                    (props.topTriangle ? " sbTopTriangle" : "") +
-                    (props.opacity === 1 ? " sbSolid" : "") +
-                    ` ${props.extraClass}`
-                }
+                className={[
+                    "sponsorBlockTooltip",
+                    props.displayTriangle || props.topTriangle ? "sbTriangle" : "",
+                    props.topTriangle ? "sbTopTriangle" : "",
+                    props.opacity === 1 ? "sbSolid" : "",
+                    props.extraClass,
+                ]
+                    .filter(Boolean)
+                    .join(" ")}
             >
                 <div
                     style={{

--- a/src/render/PersistedTooltip.tsx
+++ b/src/render/PersistedTooltip.tsx
@@ -1,0 +1,116 @@
+import { TooltipProps } from "../components/Tooltip";
+import { Tooltip } from "./Tooltip";
+
+
+/**
+ * `PersistedTooltip` 类的初始化参数，继承自 `TooltipProps`。
+ */
+interface PersistedTooltipProps extends TooltipProps {
+    /**
+     * 可选属性，指定用户交互结束后工具提示保持可见的持续时间（以毫秒为单位），默认为500毫秒。
+     */
+    persistTime?: number;
+}
+
+/**
+ * `PersistedTooltip` 类用于管理一个持久化的工具提示（Tooltip），
+ * 提供了显示和隐藏工具提示的功能，并支持在鼠标悬停时拦截隐藏操作。
+ *
+ * ### 功能描述
+ * - 工具提示可以在延迟指定的持续时间后再隐藏。
+ * - 鼠标悬停在工具提示上时，可以阻止其隐藏。
+ * - 提供手动打开和关闭工具提示的方法。
+ */
+class PersistedTooltip {
+    /**
+     * 管理的 Tooltip 实例
+     */
+    tooltip: Tooltip;
+
+    /**
+     * 延迟时间结束计时器
+     */
+    persistEndTimer: NodeJS.Timeout;
+
+    /**
+     * 延迟时间：由props传入，单位毫秒，默认为500毫秒
+     */
+    persistTime: number;
+
+    constructor(props: PersistedTooltipProps) {
+        this.tooltip = new Tooltip(props);
+        this.persistTime = props.persistTime ?? 500;
+        this.tooltipHideNow();
+
+        /**
+         * 事件监听：
+         * 鼠标进入工具提示时，中断隐藏操作。
+         * 鼠标离开工具提示时，触发隐藏操作。
+         */
+        this.tooltip.container.addEventListener("mouseenter", () => {
+            this.tooltipInterruptHiding();
+        });
+
+        this.tooltip.container.addEventListener("mouseleave", () => {
+            this.tooltipToHidden();
+        });
+    }
+
+    /**
+     * 将工具提示设置为可见状态，立即显示。
+     */
+    private tooltipToVisible() {
+        this.tooltip.container.style.transition = "";
+        this.tooltip.container.style.display = "";
+        this.tooltip.container.style.opacity = "1";
+    }
+
+    /**
+     * 将工具提示设置为隐藏状态，触发渐隐效果，并在延迟时间后完全隐藏。
+     */
+    private tooltipToHidden() {
+        this.tooltipInterruptHiding();
+        this.tooltip.container.style.transition = `opacity ${this.persistTime}ms`;
+        this.tooltip.container.style.opacity = "0";
+        this.persistEndTimer = setTimeout(() => {
+            this.tooltipHideNow();
+        }, this.persistTime);
+    }
+
+    /**
+     * 设置为完全隐藏状态，不触发渐隐效果。
+     */
+    private tooltipHideNow() {
+        this.tooltip.container.style.display = "none";
+        this.tooltip.container.style.transition = "";
+    }
+
+    /**
+     * 中断隐藏操作，取消任何正在进行的隐藏计时器，并将 Tooltip 设置为可见状态。
+     */
+    private tooltipInterruptHiding() {
+        if (this.persistEndTimer) {
+            clearTimeout(this.persistEndTimer);
+            this.tooltipToVisible();
+        }
+    }
+
+    /**
+     * 手动打开工具提示。如果工具提示正在隐藏的过程中，会取消隐藏操作并立即显示。
+     */
+    open() {
+        if (this.persistEndTimer) {
+            clearTimeout(this.persistEndTimer);
+        }
+        this.tooltipToVisible();
+    }
+
+    /**
+     * 手动关闭工具提示。工具提示会以指定的持续时间渐隐后隐藏。如果工具提示正在隐藏的过程中，会重新计时。
+     */
+    close() {
+        this.tooltipToHidden();
+    }
+}
+
+export default PersistedTooltip;

--- a/test/bvidAvidUtils.test.ts
+++ b/test/bvidAvidUtils.test.ts
@@ -1,12 +1,13 @@
-import { CalculateAvidToBvid } from "../src/utils/bvidAvidUtils";
-const testCases: [number | string, string][] = [
-    [2, "BV1xx411c7mD"],
-    ["170001", "BV17x411w7KC"],
-    ["455017605", "BV1Q541167Qg"],
-    [882584971, "BV1mK4y1C7Bz"],
-    ["80433022", "BV1GJ411x7h7"],
-    [713984017, "BV18X4y1N7Yh"],
-    [113864347752328, "BV1CDwbeEE46"],
+import { BVID } from "../src/types";
+import { CalculateAvidToBvid, CalculateBvidToAvid } from "../src/utils/bvidAvidUtils";
+const testCases: [number | string, BVID][] = [
+    [2, "BV1xx411c7mD" as BVID],
+    ["170001", "BV17x411w7KC" as BVID],
+    ["455017605", "BV1Q541167Qg" as BVID],
+    [882584971, "BV1mK4y1C7Bz" as BVID],
+    ["80433022", "BV1GJ411x7h7" as BVID],
+    [713984017, "BV18X4y1N7Yh" as BVID],
+    [113864347752328, "BV1CDwbeEE46" as BVID],
 ];
 
 describe("AV号转BV号", () => {
@@ -20,7 +21,7 @@ describe("AV号转BV号", () => {
 describe("BV号转AV号", () => {
     testCases.forEach(([avid, bvid]) => {
         test(`${bvid} -> av${avid}`, () => {
-            expect(CalculateAvidToBvid(avid)).toBe(bvid);
+            expect(CalculateBvidToAvid(bvid)).toBe(Number(avid));
         });
     });
 });


### PR DESCRIPTION
- [x] 我同意我的所有贡献将以GPL-3.0协议开源。

***

本次PR主要是一些小更新：
- 修复了一处测试代码错误
- 为 CategoryPill 的 Tooltip 组件添加了渐隐效果和鼠标交互事件，详情参见 [`PersistedTooltip.tsx`](https://github.com/hanydd/BilibiliSponsorBlock/blob/a07153614eda118e7b34d398062298f65ce00888/src/render/PersistedTooltip.tsx) 类的注释说明
- 在 CategoryPill 的 Tooltip 中添加投票提示，效果如下图所示：
![image](https://github.com/user-attachments/assets/9c7bea1a-f020-4933-a1c6-223b31c4c0a4)

