### PR TITLE
Feat: Hide full video sponsor label on pages

### DIFF
--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -799,9 +799,33 @@
         "message": "当整个视频都是某一类别时显示图标",
         "description": "Referring to the category pill that is now shown on videos that are entirely sponsor or entirely selfpromo"
     },
-    "fullVideoLabelsOnThumbnails": {
-        "message": "在视频封面上显示标签",
+    "fullVideoLabelsOnThumbnailsMode": {
+        "message": "当整个视频都是某一类别时在视频卡片上? ",
         "description": "Referring to the category pill that is shown on videos that are entirely sponsor or entirely selfpromo on recommended videos, in searches or on the homepage."
+    },
+    "fullVideoLabelsOnThumbnailsMode0": {
+        "message": "无操作"
+    },
+    "fullVideoLabelsOnThumbnailsMode1": {
+        "message": "显示标签"
+    },
+    "fullVideoLabelsOnThumbnailsMode2": {
+        "message": "隐藏此视频卡片 - 不推荐"
+    },
+    "fullVideoLabelsOnThumbnailsMode2_Warning": {
+        "message": "这会隐藏大量视频卡片，因为目前有大量随意的提交污染数据库, 这可能会隐藏你想看的内容。这还会影响排版, 请谨慎使用此选项。\n而且被隐藏后不会提示你有视频被隐藏了且无法手动查看。\n我们更推荐启用 \"模糊此视频卡片 - 鼠标悬浮可查看内容\"。"
+    },
+    "fullVideoLabelsOnThumbnailsMode3": {
+        "message": "模糊此视频卡片 - 鼠标悬浮可查看内容"
+    },
+    "fullVideoLabelsOnThumbnailsMode4": {
+        "message": "模糊此视频卡片 - 不推荐"
+    },
+    "fullVideoLabelsOnThumbnailsMode5": {
+        "message": "遮挡此视频卡片 - 不推荐"
+    },
+    "fullVideoBlock": {
+        "message": "此内容已被B站空降助手屏蔽"
     },
     "previewColor": {
         "message": "未提交颜色",

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -799,9 +799,32 @@
         "message": "當整個影片都是某一類別時顯示圖示",
         "description": "Referring to the category pill that is now shown on videos that are entirely sponsor or entirely selfpromo"
     },
-    "fullVideoLabelsOnThumbnails": {
-        "message": "在影片封面上顯示標籤",
-        "description": "Referring to the category pill that is shown on videos that are entirely sponsor or entirely selfpromo on recommended videos, in searches or on the homepage."
+    "fullVideoLabelsOnThumbnailsMode": {
+        "message": "當整個影片都是某一類別時在影片卡片上? "
+    },
+    "fullVideoLabelsOnThumbnailsMode0": {
+        "message": "無動作"
+    },
+    "fullVideoLabelsOnThumbnailsMode1": {
+        "message": "顯示標籤"
+    },
+    "fullVideoLabelsOnThumbnailsMode2": {
+        "message": "隱藏此影片卡片 - 不推薦"
+    },
+    "fullVideoLabelsOnThumbnailsMode2_Warning": {
+        "message": "這將隱藏大量影片卡片，因為目前資料庫中存在大量隨意提交的污染內容，這可能會意外隱藏你想觀看的影片。這還會影響排版, 請謹慎使用此功能。\n隱藏後不會提示你有片段被隱藏，且無法手動查看。\n我們更推薦啟用「模糊此影片卡片 - 滑鼠懸停可查看內容」。"
+    },
+    "fullVideoLabelsOnThumbnailsMode3": {
+        "message": "模糊此影片卡片 - 滑鼠懸停可查看內容"
+    },
+    "fullVideoLabelsOnThumbnailsMode4": {
+        "message": "模糊此影片卡片 - 不推薦"
+    },
+    "fullVideoLabelsOnThumbnailsMode5": {
+        "message": "遮擋此影片卡片 - 不推薦"
+    },
+    "fullVideoBlock": {
+        "message": "此內容已被B站空降助手封鎖"
     },
     "previewColor": {
         "message": "未提交顏色",

--- a/public/content.css
+++ b/public/content.css
@@ -1000,7 +1000,7 @@ input::-webkit-inner-spin-button {
 	margin: 0.4em;
 	align-items: center;
 	transition: border-radius 0.4s 0.05s;
-	z-index: 100;
+	z-index: 99;
 }
 
 #dynamicSponsorLabel svg {
@@ -1048,7 +1048,7 @@ input::-webkit-inner-spin-button {
 	margin: 0.3em;
     align-items: center;
 	transition: border-radius 0.4s 0.05s;
-	z-index: 100;
+	z-index: 99;
 }
 
 #commentSponsorLabel svg {

--- a/public/options/options.html
+++ b/public/options/options.html
@@ -188,7 +188,7 @@
 					<div class="small-description">__MSG_audioNotificationDescription__</div>
 				</div>
 
-				<div data-type="toggle" data-sync="fullVideoSegments" class="no-bottom-border">
+				<div data-type="toggle" data-sync="fullVideoSegments">
 					<div class="switch-container">
 						<label class="switch">
 							<input id="fullVideoSegments" type="checkbox" checked />
@@ -196,15 +196,20 @@
 						</label>
 						<label class="switch-label" for="fullVideoSegments"> __MSG_fullVideoSegments__ </label>
 					</div>
-				</div>
-
-				<div data-type="toggle" data-sync="fullVideoLabelsOnThumbnails" data-dependent-on="fullVideoSegments">
-					<div class="switch-container">
-						<label class="switch">
-							<input id="fullVideoLabelsOnThumbnails" type="checkbox" checked />
-							<span class="slider round"></span>
-						</label>
-						<label class="switch-label" for="fullVideoLabelsOnThumbnails"> __MSG_fullVideoLabelsOnThumbnails__ </label>
+				
+					<div data-type="selector" data-sync="fullVideoLabelsOnThumbnailsMode" data-dependent-on="fullVideoSegments">
+						<br />
+				
+						<label class="optionLabel" for="fullVideoLabelsOnThumbnailsMode">__MSG_fullVideoLabelsOnThumbnailsMode__:</label>
+				
+						<select id="fullVideoLabelsOnThumbnailsMode" class="selector-element optionsSelector">
+							<option value="0">__MSG_fullVideoLabelsOnThumbnailsMode0__</option>
+							<option value="1">__MSG_fullVideoLabelsOnThumbnailsMode1__</option>
+							<option value="3">__MSG_fullVideoLabelsOnThumbnailsMode3__</option>
+							<option value="2" data-confirm-message="fullVideoLabelsOnThumbnailsMode2_Warning">__MSG_fullVideoLabelsOnThumbnailsMode2__</option>
+							<option value="4">__MSG_fullVideoLabelsOnThumbnailsMode4__</option>
+							<option value="5">__MSG_fullVideoLabelsOnThumbnailsMode5__</option>
+						</select>
 					</div>
 				</div>
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ import {
     SponsorHideType,
     DynamicSponsorSelection,
     DynamicSponsorOption,
+    HideFullVideoLabels,
 } from "./types";
 import { Keybind, ProtoConfig, keybindEquals } from "./config/config";
 import { HashedValue } from "./utils/hash";
@@ -39,7 +40,7 @@ interface SBConfig {
     checkTimeDanmakuSkip: boolean;
     muteSegments: boolean;
     fullVideoSegments: boolean;
-    fullVideoLabelsOnThumbnails: boolean;
+    fullVideoLabelsOnThumbnailsMode: number;
     manualSkipOnFullVideo: boolean;
     trackViewCount: boolean;
     trackViewCountInPrivate: boolean;
@@ -244,13 +245,23 @@ function migrateOldSyncFormats(config: SBConfig) {
     }
 
     //动态贴片设置变量名迁移 // 0.8.1
-    if (config["dynamicSponsorBlockerer"]) {
-        config["dynamicAndCommentSponsorBlocker"] = config["dynamicSponsorBlockerer"];
-        delete config["dynamicSponsorBlockerer"];
+    if (config["dynamicSponsorBlocker"]) {
+        config["dynamicAndCommentSponsorBlocker"] = config["dynamicSponsorBlocker"];
+        delete config["dynamicSponsorBlocker"];
     }
     if (config["dynamicSponsorWhitelistedChannels"]) {
         config["dynamicAndCommentSponsorWhitelistedChannels"] = config["dynamicSponsorWhitelistedChannels"];
         delete config["dynamicSponsorWhitelistedChannels"];
+    }
+    //当整个视频都是某一类别时操作选项迁移
+    if (config["fullVideoLabelsOnThumbnails"]) {
+        if (config["fullVideoLabelsOnThumbnails"] === true) {
+            config["fullVideoLabelsOnThumbnailsMode"] = HideFullVideoLabels.Overlay;
+        } else {
+            config["fullVideoLabelsOnThumbnailsMode"] = HideFullVideoLabels.Disabled;
+        }
+        //fullVideoLabelsOnThumbnails被移除 0.9.2
+        delete config["fullVideoLabelsOnThumbnails"];
     }
 }
 
@@ -278,7 +289,7 @@ const syncDefaults = {
 
     muteSegments: true,
     fullVideoSegments: true,
-    fullVideoLabelsOnThumbnails: true,
+    fullVideoLabelsOnThumbnailsMode: HideFullVideoLabels.Overlay,
     manualSkipOnFullVideo: false,
     trackViewCount: true,
     trackViewCountInPrivate: true,

--- a/src/options.ts
+++ b/src/options.ts
@@ -300,6 +300,14 @@ async function init() {
                     let value: string | number = selectorElement.value;
                     if (!isNaN(Number(value))) value = Number(value);
 
+                    const selectedOption = selectorElement.selectedOptions[0];
+                    const confirmMessage = selectedOption.getAttribute("data-confirm-message");
+
+                    if (confirmMessage && !confirm(chrome.i18n.getMessage(confirmMessage))) {
+                        selectorElement.value = Config.config[option];
+                        return;
+                    }
+
                     Config.config[option] = value;
                 });
                 break;

--- a/src/render/DynamicAndCommentSponsorBlock.tsx
+++ b/src/render/DynamicAndCommentSponsorBlock.tsx
@@ -259,7 +259,7 @@ function shadowRootStyle(element: HTMLElement) {
                 margin: 0.4em;
                 align-items: center;
                 transition: border-radius 0.4s 0.05s;
-	            z-index: 100;
+	            z-index: 99;
             }
 
             #dynamicSponsorLabel svg {
@@ -307,7 +307,7 @@ function shadowRootStyle(element: HTMLElement) {
                 margin: 0.3em;
                 align-items: center;
                 transition: border-radius 0.4s 0.05s;
-	            z-index: 100;
+	            z-index: 99;
             }
 
             #commentSponsorLabel svg {

--- a/src/thumbnail-utils/thumbnails.ts
+++ b/src/thumbnail-utils/thumbnails.ts
@@ -5,6 +5,7 @@ import { BVID, NewVideoID } from "../types";
 import { waitFor } from "../utils/";
 import { getBvIDFromURL } from "../utils/parseVideoID";
 import { getLabelAnchorSelector, getLinkAttribute, getLinkSelectors } from "./thumbnail-selectors";
+import { HideFullVideoLabels } from "../types";
 
 export async function labelThumbnails(thumbnails: HTMLElement[], containerType: string): Promise<void> {
     await Promise.all(thumbnails.map((t) => labelThumbnail(t as HTMLElement, containerType)));
@@ -24,7 +25,7 @@ export async function labelThumbnailProcess(
     thumbnail: HTMLElement,
     containerType: string
 ): Promise<HTMLElement | null> {
-    if (!Config.config?.fullVideoSegments || !Config.config?.fullVideoLabelsOnThumbnails) {
+    if (!Config.config?.fullVideoSegments || Config.config?.fullVideoLabelsOnThumbnailsMode === HideFullVideoLabels.Disabled) {
         await hideThumbnailLabel(thumbnail);
         return null;
     }
@@ -75,6 +76,8 @@ export async function labelThumbnailProcess(
         );
         text.innerText = chrome.i18n.getMessage(`category_${category}`);
         overlay.classList.add("sponsorThumbnailLabelVisible");
+
+        if ([HideFullVideoLabels.Hide, HideFullVideoLabels.BlurRevealOnHover, HideFullVideoLabels.BlurRevealOnHover, HideFullVideoLabels.SolidCover].includes(Config.config.fullVideoLabelsOnThumbnailsMode)) hideVideoCard(thumbnail, containerType);
     }
 
     return overlay;
@@ -171,4 +174,101 @@ export function insertSBIconDefinition(element: HTMLElement = document.body) {
   </defs>
 </svg>`;
     element.appendChild(container);
+}
+
+function hideVideoCard(thumbnail: HTMLElement, containerType: string) {
+    let card: HTMLElement;
+    switch (containerType) {
+        case "channelDynamic":
+            card = (thumbnail.parentNode.parentNode.parentNode.parentNode as HTMLElement);
+            break;
+        case "dynamic":
+        case "spaceUpload": 
+            card = (thumbnail.parentNode.parentNode.parentNode as HTMLElement);
+            break;
+        case "mainPageRecommendation":
+        case "bewlybewlyMainPage": 
+            card = (thumbnail.parentNode.parentNode as HTMLElement);
+            break;
+        case "search":
+        case "spaceMain": 
+            card = (thumbnail.parentNode as HTMLElement);
+            break;
+        case "dynamicPopup":
+        case "favPopup":
+        case "historyPopup":
+        case "playerListPod":
+        case "playerListPodVideo":
+        case "listPlayerSideRecommendation":
+        case "playerSideRecommendation":
+        case "history":
+        case "bilibiliGateMainPage":
+            card = thumbnail
+            break;
+    }
+
+    if ([HideFullVideoLabels.BlurRevealOnHover, HideFullVideoLabels.BlurRevealOnHover, HideFullVideoLabels.SolidCover].includes(Config.config.fullVideoLabelsOnThumbnailsMode)) {
+        Blur(card);
+    } else {
+        Hide(card);
+    }
+
+    async function Blur(card: HTMLElement) {
+        if (!card || card.querySelector('.bsb-blur-mask')) return;
+
+        const mask = document.createElement('div');
+        mask.innerText = chrome.i18n.getMessage("fullVideoBlock");
+        mask.className = 'bsb-blur-mask';
+        mask.style.cssText = `
+        position: absolute;
+        pointer-events: none;
+        z-index: 99;
+        opacity: 1;
+        transition: all 0.5s ease;
+        border-radius: 6px;
+        inset: -0.1em;
+        color: var(--text2);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        pointerEvents: none;
+        `;
+        if (Config.config.fullVideoLabelsOnThumbnailsMode === HideFullVideoLabels.SolidCover) {
+           mask.style.backgroundColor = "var(--graph_bg_regular)";
+           mask.style.pointerEvents = "all";
+        } else {
+            mask.style.backdropFilter = "blur(8px)";
+        }
+
+        card.style.position = 'relative';
+        card.appendChild(mask);
+
+        const label = card.querySelector(".sponsorThumbnailLabel").cloneNode(true) as HTMLElement;
+        label.style.zIndex = "100";
+        label.style.transition = "all 0.5s ease";
+        label.style.position = "absolute";
+        if (Config.config.fullVideoLabelsOnThumbnailsMode === HideFullVideoLabels.BlurRevealOnHover) {
+            label.style.pointerEvents = "none";
+        } else {
+            label.style.pointerEvents = "all";
+        }
+
+        card.appendChild(label);
+        
+        if (Config.config.fullVideoLabelsOnThumbnailsMode === HideFullVideoLabels.BlurRevealOnHover) {
+            card.addEventListener('mouseenter', () => {
+                mask.style.opacity = '0';
+                label.style.opacity = "0";
+            });
+            card.addEventListener('mouseleave', () => {
+                mask.style.opacity = '1';
+                label.style.opacity = "0.7";
+            });
+        }
+    }
+
+    function Hide(card: HTMLElement) {
+        card.style.setProperty("display", "none", "important");
+    }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -236,3 +236,12 @@ export enum NoticeVisbilityMode {
     FadedForAutoSkip = 3,
     FadedForAll = 4,
 }
+
+export enum HideFullVideoLabels {
+    Disabled = 0,
+    Overlay = 1,
+    Hide = 2,
+    BlurRevealOnHover  = 3,
+    BlurAlways = 4,
+    SolidCover = 5,
+}


### PR DESCRIPTION
- [x] 我同意我的所有贡献将以GPL-3.0协议开源。

***
#152 

c3cf1769d15c3e34b91c36449b8c92268233ea70 使selector的option支持data-confirm-message（警告与确定操作）
<img width="572" height="63" alt="image" src="https://github.com/user-attachments/assets/60b283ae-53f2-4ab9-a32d-a4af7826218e" />
选择此选项后弹出
<img width="462" height="206" alt="image" src="https://github.com/user-attachments/assets/8dd4e27b-2879-4dc6-aade-8bacfb98ab4b" />

bd6800867ae10a2fa519b12db8e192e382bbca59 可以使有整个视频标签的视频在各种地方隐藏，模糊，遮蔽，与仅添加标签
***
## 部分效果截图

### 播放列表-文字形
<img width="361" height="60" alt="image" src="https://github.com/user-attachments/assets/82d20eb4-f5c0-48b6-985d-a3b52413da74" />

### UP主主页
<img width="1326" height="589" alt="image" src="https://github.com/user-attachments/assets/bc7f92bc-f428-4409-a200-c01f2a477510" />

### 动态主页投稿视频
<img width="736" height="459" alt="image" src="https://github.com/user-attachments/assets/28834928-27c0-4f4f-b033-4944eefbd2bc" />

***
## 设置截图

<img width="561" height="276" alt="image" src="https://github.com/user-attachments/assets/0a247f4b-50ca-4c18-b6c6-247e18339a24" />

