### PR TITLE
Exclude live pages from all content scripts

### DIFF
--- a/manifest/chrome-manifest-extra.json
+++ b/manifest/chrome-manifest-extra.json
@@ -40,6 +40,9 @@
       "matches": [
         "https://*.bilibili.com/*"
       ],
+      "exclude_matches": [
+        "https://live.bilibili.com/*"
+      ],
       "all_frames": true,
       "js": [
         "./js/document.js"


### PR DESCRIPTION
- [x] 我同意我的所有贡献将以GPL-3.0协议开源。

***
**改动**
- Chrome：为两条 content_scripts（ISOLATED 与 MAIN）都增加
  exclude_matches: ["https://live.bilibili.com/*"]。

**原因**
此前的修复 https://github.com/hanydd/BilibiliSponsorBlock/commit/d467d15789aff05fa523afeda104166f4ab08342 只排除了第一条，另一条仍会在直播页执行。
#179

本 PR 使所有 content_scripts 都跳过直播域名。