### PR TITLE
refactor: use /api/skipSegments for thumbnail label fetching

### DIFF
--- a/src/requests/background/videoLabelRequest.ts
+++ b/src/requests/background/videoLabelRequest.ts
@@ -7,7 +7,12 @@ import { LabelBlock } from "../type/requestType";
 import { videoLabelCache } from "./backgroundCache";
 
 async function fetchLabelBlock(prefix: string, skipServerCache: boolean): Promise<LabelBlock> {
-    const response = await callAPI("GET", `/api/skipSegments/${prefix}`, { actionType: "full" }, skipServerCache);
+    const response = await callAPI(
+        "GET",
+        `/api/skipSegments/${prefix}`,
+        { categories: '["sponsor","selfpromo","exclusive_access"]', actionType: "full" },
+        skipServerCache
+    );
 
     if (!response.ok || response.status !== 200) return {} as LabelBlock;
 

--- a/src/requests/background/videoLabelRequest.ts
+++ b/src/requests/background/videoLabelRequest.ts
@@ -1,5 +1,5 @@
 import Config from "../../config";
-import { BVID, Category, CategorySkipOption, NewVideoID } from "../../types";
+import { Category, CategorySkipOption, NewVideoID, SponsorTimeHashedID } from "../../types";
 import { getVideoIDHash } from "../../utils/hash";
 import { parseBvidAndCidFromVideoId } from "../../utils/videoIdUtils";
 import { callAPI } from "../background-request-proxy";
@@ -7,13 +7,13 @@ import { LabelBlock } from "../type/requestType";
 import { videoLabelCache } from "./backgroundCache";
 
 async function fetchLabelBlock(prefix: string, skipServerCache: boolean): Promise<LabelBlock> {
-    const response = await callAPI("GET", `/api/videoLabels/${prefix}`, {}, skipServerCache);
+    const response = await callAPI("GET", `/api/skipSegments/${prefix}`, { actionType: "full" }, skipServerCache);
 
     if (!response.ok || response.status !== 200) return {} as LabelBlock;
 
-    const data = JSON.parse(response.responseText) as Array<{ videoID: BVID; segments: Array<{ category: Category }> }>;
+    const data = JSON.parse(response.responseText) as SponsorTimeHashedID[];
     const block: LabelBlock = Object.fromEntries(
-        (data || []).map((video) => [video.videoID, video.segments?.[0]?.category]).filter(([, c]) => !!c)
+        (data || []).map((video) => [video.videoID, video.segments?.[0]?.category as Category]).filter(([, c]) => !!c)
     ) as LabelBlock;
     return block;
 }


### PR DESCRIPTION
- [x] 我同意我的所有贡献将以GPL-3.0协议开源。

***
在封面标签相关源代码中使用了一个未在Wiki未公开的API`videoLabels`用于获取封面标签数据 如下
https://bsbsb.top/api/videoLabels?videoID=BV18E4m1d7b7
```
[
  {
    "cid": "1651410374",
    "category": "sponsor",
    "UUID": "c1c92e1221a2ea2906801ef7461a8d86f801025d46c45279d9a1e611e48a2f0c7",
    "locked": 0,
    "votes": 0,
    "videoDuration": 553
  }
]
```
但是这个封面标签API并不会考虑片段的`shadowHidden`状态 
https://bsbsb.top/api/searchSegments?videoID=BV18E4m1d7b7
```
{
  "segmentCount": 3,
  "page": 0,
  "segments": [
    ...
    {
      "cid": "1651410374",
      "UUID": "c1c92e1221a2ea2906801ef7461a8d86f801025d46c45279d9a1e611e48a2f0c7",
      "timeSubmitted": 1752754432685,
      "startTime": 0,
      "endTime": 0,
      "category": "sponsor",
      "actionType": "full",
      "votes": 0,
      "views": 0,
      "locked": 0,
      "hidden": 0,
      "shadowHidden": 1,
      "userID": "5d3a6df7a379356ce144371bdea3bc2a1e22f560f874c7830484e633b9a4708e",
      "description": ""
    }
  ]
}
```
在 https://bsbsb.top/api/skipSegments?videoID=BV18E4m1d7b7 无该片段
***
导致即使一个*恶意*封面标签提交被社区发现并投反对票会在用户侧的片段列表中隐藏但是在封面标签API中并不会隐藏
本修改修改了`videoLabels` 为 `skipSegments `获取已经被`shadowHidden`筛选的片段
***
## 也可以选择在服务器侧进行修复 会更直接一点