### PR TITLE
i18n: add Korean (ko) translation

### DIFF
--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -1,0 +1,1476 @@
+{
+    "fullName": {
+        "message": "小电视空降助手",
+        "description": "Name of the extension."
+    },
+    "shortName": {
+        "message": "空降助手"
+    },
+    "Description": {
+        "message": "협찬 광고 때문에 책상을 엎고 싶으셨죠?(/= _ =)/~┴┴ 협찬 광고가 끝나는 지점이나 하이라이트 순간으로 정확하게 데려다줍니다. 영상 속 협찬 광고, 구독 알림 등 불필요한 구간을 자동으로 건너뜁니다. 직접 영상의 광고 구간을 표시해서 업로드할 수도 있으며, 여러분의 기여로 모든 사용자가 혜택을 누리게 됩니다.",
+        "description": "Description of the extension."
+    },
+    "400": {
+        "message": "잘못된 요청입니다"
+    },
+    "409": {
+        "message": "이미 제출하셨습니다"
+    },
+    "confirm": {
+        "message": "확인"
+    },
+    "close": {
+        "message": "닫기"
+    },
+    "channelWhitelisted": {
+        "message": "업로더가 화이트리스트에 추가되었습니다!"
+    },
+    "Segment": {
+        "message": "구간"
+    },
+    "Segments": {
+        "message": "구간"
+    },
+    "SegmentsCap": {
+        "message": "구간"
+    },
+    "upvoteButtonInfo": {
+        "message": "이 구간에 좋아요 누르기"
+    },
+    "reportButtonTitle": {
+        "message": "신고"
+    },
+    "reportButtonInfo": {
+        "message": "이 구간의 오류를 신고합니다."
+    },
+    "Dismiss": {
+        "message": "무시"
+    },
+    "Loading": {
+        "message": "불러오는 중..."
+    },
+    "Hide": {
+        "message": "다시 표시 안 함"
+    },
+    "hitGoBack": {
+        "message": "클릭하면 건너뛰기를 취소하고 이전 위치로 돌아갑니다."
+    },
+    "unskip": {
+        "message": "건너뛰기 취소"
+    },
+    "reskip": {
+        "message": "다시 건너뛰기"
+    },
+    "unmute": {
+        "message": "음소거 해제"
+    },
+    "paused": {
+        "message": "일시정지됨"
+    },
+    "manualPaused": {
+        "message": "타이머가 정지되었습니다"
+    },
+    "confirmMSG": {
+        "message": "개별 항목을 수정하거나 삭제하려면 정보 버튼을 클릭하거나,\n브라우저 오른쪽 위의 확장 프로그램 아이콘을 클릭해 팝업을 여세요."
+    },
+    "clearThis": {
+        "message": "선택한 구간을 정말 삭제하시겠습니까?"
+    },
+    "Unknown": {
+        "message": "구간 시간을 제출하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
+    },
+    "sponsorFound": {
+        "message": "이 영상은 데이터베이스에 건너뛸 수 있는 구간이 있습니다!"
+    },
+    "sponsor404": {
+        "message": "건너뛸 수 있는 구간을 찾지 못했습니다"
+    },
+    "sponsorStart": {
+        "message": "지금부터 구간 시작"
+    },
+    "sponsorEnd": {
+        "message": "지금 구간 종료"
+    },
+    "sponsorCancel": {
+        "message": "구간 생성 취소"
+    },
+    "noVideoID": {
+        "message": "영상을 찾지 못했습니다.\n인식 오류라면 이 페이지를 새로고침 해주세요."
+    },
+    "refreshSegments": {
+        "message": "구간 새로고침"
+    },
+    "success": {
+        "message": "성공!"
+    },
+    "voted": {
+        "message": "투표 완료!"
+    },
+    "serverDown": {
+        "message": "서버가 다운된 것 같습니다 (/ﾟДﾟ)/"
+    },
+    "connectionError": {
+        "message": "연결 오류. 오류 코드: "
+    },
+    "segmentsStillLoading": {
+        "message": "구간을 불러오는 중입니다..."
+    },
+    "clearTimes": {
+        "message": "구간 지우기"
+    },
+    "openPopup": {
+        "message": "小电视空降助手 팝업 열기"
+    },
+    "closePopup": {
+        "message": "팝업 닫기"
+    },
+    "closeIcon": {
+        "message": "닫기 아이콘"
+    },
+    "OpenSubmissionMenu": {
+        "message": "제출 메뉴 열기"
+    },
+    "sortSegments": {
+        "message": "구간 정렬"
+    },
+    "submitCheck": {
+        "message": "정말 제출하시겠습니까?"
+    },
+    "whitelistChannel": {
+        "message": "업로더를 화이트리스트에 추가"
+    },
+    "removeFromWhitelist": {
+        "message": "업로더를 화이트리스트에서 제거"
+    },
+    "voteOnTime": {
+        "message": "구간에 투표"
+    },
+    "Submissions": {
+        "message": "제출 수"
+    },
+    "savedPeopleFrom": {
+        "message": "여러분이 절약해 드린 시간은 "
+    },
+    "viewLeaderboard": {
+        "message": "리더보드"
+    },
+    "recordTimesDescription": {
+        "message": "제출"
+    },
+    "submissionEditHint": {
+        "message": "제출을 클릭하면 구간 편집 화면이 표시됩니다",
+        "description": "Appears in the popup to inform them that editing has been moved to the video player."
+    },
+    "popupHint": {
+        "message": "팁: 옵션에서 제출 동작에 단축키를 지정할 수 있습니다"
+    },
+    "clearTimesButton": {
+        "message": "시간 지우기"
+    },
+    "Username": {
+        "message": "사용자 이름"
+    },
+    "setUsername": {
+        "message": "사용자 이름 설정"
+    },
+    "copyPublicID": {
+        "message": "공개 사용자 ID 복사"
+    },
+    "copySegmentID": {
+        "message": "구간 ID 복사"
+    },
+    "hideThis": {
+        "message": "숨기기"
+    },
+    "Options": {
+        "message": "옵션"
+    },
+    "showButtons": {
+        "message": "플레이어에 버튼 표시"
+    },
+    "hideButtons": {
+        "message": "플레이어에서 버튼 숨기기"
+    },
+    "hideButtonsDescription": {
+        "message": "플레이어 컨트롤 바에서 구간 제출 버튼을 숨깁니다"
+    },
+    "showSkipButton": {
+        "message": "플레이어에 하이라이트로 건너뛰기 버튼 표시"
+    },
+    "showInfoButton": {
+        "message": "플레이어에 정보 버튼 표시"
+    },
+    "hideInfoButton": {
+        "message": "플레이어에서 정보 버튼 숨기기"
+    },
+    "autoHideInfoButton": {
+        "message": "정보 버튼 자동 숨기기"
+    },
+    "showUploadButton": {
+        "message": "플레이어에 업로드 버튼 표시"
+    },
+    "hideDeleteButton": {
+        "message": "플레이어에서 삭제 버튼 숨기기"
+    },
+    "showDeleteButton": {
+        "message": "플레이어에 삭제 버튼 표시"
+    },
+    "enableViewTracking": {
+        "message": "건너뛴 횟수 통계 추적 사용"
+    },
+    "whatViewTracking": {
+        "message": "이 기능은 사용자가 어떤 구간을 건너뛰었는지 추적하여, 제출된 구간이 얼마나 많은 사람에게 도움이 되었는지 알려줍니다. 또한 좋아요 수를 근거로 삼아 스팸이 데이터베이스를 오염시키지 않도록 합니다. 구간을 건너뛸 때마다 서버로 메시지 하나가 전송됩니다. 더 정확한 통계를 위해 이 설정을 켜두시는 것을 권장합니다. :)"
+    },
+    "enableViewTrackingInPrivate": {
+        "message": "시크릿 모드에서도 건너뛴 횟수 추적 사용"
+    },
+    "enableTrackDownvotes": {
+        "message": "싫어요한 구간 저장"
+    },
+    "whatTrackDownvotes": {
+        "message": "싫어요를 누른 구간을 저장하여, 새로고침 후에도 계속 숨겨진 상태로 유지합니다"
+    },
+    "trackDownvotesWarning": {
+        "message": "경고: 이 기능을 끄면 이전에 저장된 모든 싫어요 기록이 삭제됩니다"
+    },
+    "enableTrackDownvotesInPrivate": {
+        "message": "시크릿 모드에서의 싫어요 기록 저장"
+    },
+    "enableQueryByHashPrefix": {
+        "message": "해시 접두사로 조회"
+    },
+    "whatQueryByHashPrefix": {
+        "message": "영상 ID 전체 대신 영상 ID 해시값의 앞 4자리만으로 서버에 구간을 조회합니다. 서버는 유사한 해시값을 가진 모든 영상 데이터를 반환합니다."
+    },
+    "enableShowCategoryWithoutPermission": {
+        "message": "제출 권한이 없어도 제출 메뉴에 카테고리 표시"
+    },
+    "whatShowCategoryWithoutPermission": {
+        "message": "일부 카테고리는 최소 권한 요건이 있어 제출하려면 허가가 필요합니다"
+    },
+    "showNotice": {
+        "message": "건너뛰기 알림 다시 표시"
+    },
+    "showSkipNotice": {
+        "message": "구간을 건너뛸 때 알림 팝업 표시"
+    },
+    "showCategoryGuidelines": {
+        "message": "카테고리 설명 표시"
+    },
+    "noticeVisibilityMode0": {
+        "message": "전체 크기 건너뛰기 알림 팝업"
+    },
+    "noticeVisibilityMode1": {
+        "message": "자동 건너뛰기 시 축소된 알림 팝업"
+    },
+    "noticeVisibilityMode2": {
+        "message": "축소된 건너뛰기 알림 팝업"
+    },
+    "noticeVisibilityMode3": {
+        "message": "자동 건너뛰기 시 반투명 알림 팝업"
+    },
+    "noticeVisibilityMode4": {
+        "message": "모든 건너뛰기 알림 팝업을 반투명으로"
+    },
+    "longDescription": {
+        "message": "小电视空降助手는 빌리빌리(哔哩哔哩) 영상 속 협찬 광고, 오프닝·엔딩, 좋아요·코인·팔로우 알림 등 불필요한 구간을 자동으로 건너뛰도록 도와줍니다. 이 확장 프로그램은 크라우드소싱 방식으로 운영되며, 누구나 영상 속 광고 및 기타 구간의 시작·종료 시간을 제출할 수 있습니다. 한 사람이 정보를 제출하면, 이 확장 프로그램을 사용하는 모든 사람이 해당 구간을 바로 건너뛸 수 있습니다. 음악 영상에서 음악이 아닌 부분도 건너뛸 수 있습니다.",
+        "description": "Full description of the extension on the store pages."
+    },
+    "website": {
+        "message": "웹사이트",
+        "description": "Used on Firefox Store Page"
+    },
+    "sourceCode": {
+        "message": "소스 코드",
+        "description": "Used on Firefox Store Page"
+    },
+    "setSkipShortcut": {
+        "message": "구간 건너뛰기",
+        "description": "Keybind label"
+    },
+    "setSkipToPoiShortcut": {
+        "message": "하이라이트로 이동"
+    },
+    "setStartSponsorShortcut": {
+        "message": "구간 시작/종료",
+        "description": "Keybind label"
+    },
+    "setOpenSubmissionMenuKeybind": {
+        "message": "제출 메뉴 열기",
+        "description": "Keybind label"
+    },
+    "setSubmitKeybind": {
+        "message": "구간 제출",
+        "description": "Keybind label"
+    },
+    "setPreviewKeybind": {
+        "message": "구간 미리보기",
+        "description": "Keybind label"
+    },
+    "setCloseSkipNoticeKeybind": {
+        "message": "건너뛰기 알림 닫기",
+        "description": "Keybind label"
+    },
+    "nextFrameKeybind": {
+        "message": "(편집 제출 팝업이 열려 있을 때 적용) 다음 프레임",
+        "description": "Keybind label"
+    },
+    "previousFrameKeybind": {
+        "message": "(편집 제출 팝업이 열려 있을 때 적용) 이전 프레임",
+        "description": "Keybind label"
+    },
+    "keybindDescription": {
+        "message": "지정할 키를 눌러주세요. 조합 단축키를 사용하려면 왼쪽 옵션을 선택하세요."
+    },
+    "0": {
+        "message": "연결 시간이 초과되었습니다. 네트워크 연결을 확인해 주세요. 네트워크에 문제가 없다면 서버가 다운되었을 수 있습니다."
+    },
+    "disableSkipping": {
+        "message": "건너뛰기 켜짐"
+    },
+    "enableSkipping": {
+        "message": "건너뛰기 꺼짐"
+    },
+    "yourWork": {
+        "message": "내 정보",
+        "description": "Used to describe the section that will show you the statistics from your submissions."
+    },
+    "502": {
+        "message": "서버가 과부하 상태인 것 같습니다. 잠시 후 다시 시도해 주세요."
+    },
+    "errorCode": {
+        "message": "오류 코드: "
+    },
+    "skip": {
+        "message": "건너뛰기"
+    },
+    "mute": {
+        "message": "음소거"
+    },
+    "full": {
+        "message": "영상 전체",
+        "description": "Used for the name of the option to label an entire video as sponsor or self promotion."
+    },
+    "skip_category": {
+        "message": "{0} 구간을 건너뛸까요?"
+    },
+    "mute_category": {
+        "message": "{0} 구간을 음소거할까요?"
+    },
+    "skip_to_category": {
+        "message": "{0}(으)로 건너뛸까요?",
+        "description": "Used for skipping to things (Skip to Highlight)"
+    },
+    "autoSkipped": {
+        "message": "{0} 건너뛰기 준비 완료",
+        "description": "Example: Ready Sponsor Skipped"
+    },
+    "autoMuted": {
+        "message": "{0} 음소거 준비 완료",
+        "description": "Example: Ready Sponsor Muted"
+    },
+    "skipped": {
+        "message": "{0} 건너뜀",
+        "description": "Example: Sponsor Skipped"
+    },
+    "muted": {
+        "message": "{0} 음소거됨",
+        "description": "Example: Sponsor Muted"
+    },
+    "skipped_to_category": {
+        "message": "{0}(으)로 건너뜀",
+        "description": "Used for skipping to things (Skipped to Highlight)"
+    },
+    "disableAutoSkip": {
+        "message": "자동 건너뛰기 비활성화"
+    },
+    "enableAutoSkip": {
+        "message": "자동 건너뛰기 활성화"
+    },
+    "audioNotification": {
+        "message": "건너뛸 때 알림음 재생"
+    },
+    "audioNotificationDescription": {
+        "message": "구간을 건너뛸 때 알림음을 재생합니다. 비활성화되어 있거나 자동 건너뛰기가 꺼져 있으면 소리가 재생되지 않습니다."
+    },
+    "showTimeWithSkips": {
+        "message": "건너뛸 수 있는 구간을 제외한 영상 길이 표시"
+    },
+    "showTimeWithSkipsDescription": {
+        "message": "진행 바 아래 영상 길이 옆 괄호 안에 표시됩니다. \"진행 바에 표시\"로 지정된 구간을 포함해, 건너뛸 수 있는 모든 구간을 제외한 영상 길이를 나타냅니다."
+    },
+    "youHaveSkipped": {
+        "message": "지금까지 건너뛴 시간"
+    },
+    "minLower": {
+        "message": "분"
+    },
+    "minsLower": {
+        "message": "분"
+    },
+    "hourLower": {
+        "message": "시간"
+    },
+    "hoursLower": {
+        "message": "시간"
+    },
+    "youHaveSavedTime": {
+        "message": "여러분이 절약해 드린 시간은",
+        "description": "You've saved people from 887,362 segments (236d 15h 5.3 minutes of their lives)."
+    },
+    "youHaveSavedTimeEnd": {
+        "message": "입니다",
+        "description": "You've saved people from 887,362 segments (236d 15h 5.3 minutes of their lives)."
+    },
+    "serverStatus": {
+        "message": "서버 상태"
+    },
+    "projectRepo": {
+        "message": "프로젝트 소스"
+    },
+    "statusReminder": {
+        "message": "status.bsbsb.top에서 서버 상태를 확인하세요."
+    },
+    "changeUserID": {
+        "message": "개인 사용자 ID 가져오기/내보내기"
+    },
+    "whatChangeUserID": {
+        "message": "개인 ID는 반드시 비밀로 유지해야 합니다. 다른 사람이 개인 ID를 알게 되면 당신을 사칭할 수 있습니다. 공개 사용자 ID를 찾으려면 팝업의 클립보드 아이콘을 클릭하세요."
+    },
+    "setUserID": {
+        "message": "개인 사용자 ID 설정"
+    },
+    "userIDChangeWarning": {
+        "message": "경고: 개인 사용자 ID 변경은 되돌릴 수 없습니다. 정말 변경하시겠습니까? 만약을 대비해 기존 개인 ID를 꼭 백업해 두세요."
+    },
+    "createdBy": {
+        "message": "제작자"
+    },
+    "minDuration": {
+        "message": "최소 구간 길이(초):"
+    },
+    "minDurationDescription": {
+        "message": "설정한 값보다 짧은 구간은 건너뛰지 않으며 플레이어에도 표시되지 않습니다."
+    },
+    "enableManualSkipOnFullVideo": {
+        "message": "영상 전체가 광고로 표시된 경우 수동 건너뛰기 사용"
+    },
+    "whatManualSkipOnFullVideo": {
+        "message": "간접 광고 영상을 중간 내용은 건너뛰지 않고 전체 재생하고 싶다면, 간접 광고 수동 건너뛰기를 활성화하세요"
+    },
+    "enableSkipOnSeekToSegment": {
+        "message": "구간 중간으로 이동해도 계속 건너뛰기"
+    },
+    "whatSkipOnSeekToSegment": {
+        "message": "이 옵션을 켜면, 방향키로 빨리 감기를 해서 광고 구간 시작 부분을 건너뛰었더라도 여전히 구간 중간에 있는 경우 확장 프로그램이 해당 구간을 자동으로 건너뜁니다."
+    },
+    "optionSectionSkipNotice": {
+        "message": "건너뛰기 알림 팝업"
+    },
+    "optionSectionPlayerAndButtons": {
+        "message": "플레이어 및 버튼"
+    },
+    "showNewIcon": {
+        "message": "새 아이콘 사용"
+    },
+    "optionSectionPortVideo": {
+        "message": "이식 영상 연동"
+    },
+    "optionSectionExtensionRelated": {
+        "message": "확장 프로그램 관련 옵션"
+    },
+    "advanceSkipNotice": {
+        "message": "\"건너뛰기 알림 팝업\" 미리 표시 (\"자동 건너뛰기\"가 설정된 구간에만 적용)"
+    },
+    "skipNoticeDurationBefore": {
+        "message": "\"건너뛰기 알림 팝업\" 미리 표시 시간(초):"
+    },
+    "skipNoticeDurationBeforeDescription": {
+        "message": "구간을 건너뛰기 전에 미리 알려주는 팝업의 표시 시간입니다."
+    },
+    "skipNoticeDuration": {
+        "message": "\"건너뛰기 알림 팝업\" 건너뛴 후 또는 건너뛰기 알림 표시 시간(초):"
+    },
+    "skipNoticeDurationDescription": {
+        "message": "구간을 건너뛰었거나 건너뛰기를 알리는 팝업의 표시 시간입니다. 구간에 투표하거나 건너뛰기/건너뛰기 취소를 할 때 사용됩니다.\n수동 건너뛰기 구간의 알림 팝업은 더 오래 표시될 수 있습니다."
+    },
+    "shortCheck": {
+        "message": "다음 제출 항목은 최소 지속 시간 옵션보다 짧습니다. 이미 제출되었지만 해당 옵션 때문에 무시되었을 가능성이 있습니다. 정말 제출하시겠습니까?"
+    },
+    "customServerAddress": {
+        "message": "空降助手 서버 주소"
+    },
+    "customServerAddressDescription": {
+        "message": "小电视空降助手의 서버 주소입니다.\n자체 서버가 있는 경우가 아니라면 변경하지 않는 것을 권장합니다."
+    },
+    "cacheManagement": {
+        "message": "캐시 관리"
+    },
+    "segmentResponseCache": {
+        "message": "영상 구간 캐시"
+    },
+    "videoLabelsCache": {
+        "message": "영상 라벨 캐시"
+    },
+    "totalCacheSize": {
+        "message": "전체 캐시 크기"
+    },
+    "refreshCacheStats": {
+        "message": "통계 새로고침"
+    },
+    "clearAllCache": {
+        "message": "모든 캐시 지우기"
+    },
+    "confirmClearAllCache": {
+        "message": "모든 캐시를 지우시겠습니까? 이 작업은 되돌릴 수 없습니다."
+    },
+    "clearAllCacheSuccess": {
+        "message": "모든 캐시가 성공적으로 지워졌습니다"
+    },
+    "clearAllCacheFailed": {
+        "message": "캐시 지우기 실패"
+    },
+    "cacheManagementDescription": {
+        "message": "현재 캐시 사용 현황을 표시합니다. 캐시는 영상 로딩 속도를 높이지만 저장 공간을 사용합니다."
+    },
+    "enableCache": {
+        "message": "캐시 사용"
+    },
+    "enableCacheDescription": {
+        "message": "캐시를 사용하면 영상 구간 및 라벨을 더 빠르게 불러올 수 있습니다. 끄면 저장된 모든 캐시 데이터가 삭제됩니다."
+    },
+    "cacheType": {
+        "message": "캐시 유형"
+    },
+    "cacheSize": {
+        "message": "캐시 크기"
+    },
+    "cacheEntries": {
+        "message": "캐시 항목 수"
+    },
+    "dailyHits": {
+        "message": "오늘의 캐시 적중 횟수"
+    },
+    "dailyDataRetrieved": {
+        "message": "오늘의 캐시 조회량"
+    },
+    "save": {
+        "message": "저장"
+    },
+    "reset": {
+        "message": "초기화"
+    },
+    "customAddressError": {
+        "message": "주소 형식이 올바르지 않습니다. 앞에 http:// 또는 https://가 있고, 끝에 슬래시(/)가 없는지 확인해 주세요."
+    },
+    "areYouSureReset": {
+        "message": "정말 초기화하시겠습니까?"
+    },
+    "exportOptions": {
+        "message": "모든 옵션 가져오기/내보내기"
+    },
+    "exportOtherData": {
+        "message": "모든 기타 데이터 가져오기/내보내기"
+    },
+    "exportOptionsCopy": {
+        "message": "편집/복사"
+    },
+    "exportOptionsDownload": {
+        "message": "파일로 저장"
+    },
+    "exportOptionsUpload": {
+        "message": "파일에서 불러오기"
+    },
+    "whatExportOptions": {
+        "message": "이것은 모든 설정을 JSON 형식으로 나타낸 것입니다. 개인 사용자 ID가 포함되어 있으니 반드시 신중하게 보관하세요."
+    },
+    "setOptions": {
+        "message": "옵션 설정"
+    },
+    "exportOptionsWarning": {
+        "message": "경고: 옵션 변경은 되돌릴 수 없으며 설치된 항목을 손상시킬 수 있습니다. 정말 변경하시겠습니까? 만약을 대비해 기존 파일을 백업해 두었는지 확인하세요."
+    },
+    "incorrectlyFormattedOptions": {
+        "message": "JSON 형식이 올바르지 않습니다. 옵션이 변경되지 않았습니다."
+    },
+    "confirmNoticeTitle": {
+        "message": "구간 제출"
+    },
+    "submit": {
+        "message": "제출"
+    },
+    "cancel": {
+        "message": "취소"
+    },
+    "delete": {
+        "message": "삭제"
+    },
+    "preview": {
+        "message": "미리보기"
+    },
+    "unsubmitted": {
+        "message": "제출되지 않음"
+    },
+    "inspect": {
+        "message": "구간 시작 지점"
+    },
+    "edit": {
+        "message": "편집"
+    },
+    "copyDebugInformation": {
+        "message": "디버그 정보를 클립보드에 복사"
+    },
+    "copyDebugInformationFailed": {
+        "message": "클립보드 복사 실패"
+    },
+    "copyDebugInformationOptions": {
+        "message": "오류를 신고할 때 개발자에게 제공할 정보를 클립보드에 복사합니다. 사용자 ID, 업로더 화이트리스트, 사용자 지정 서버 주소 등 민감한 정보는 제거되지만, 사용자 에이전트, 브라우저, 운영체제, 확장 프로그램 버전 등의 정보는 여전히 포함됩니다."
+    },
+    "copyDebugInformationComplete": {
+        "message": "디버그 정보가 클립보드에 복사되었습니다. 공유하고 싶지 않은 정보는 자유롭게 제거하셔도 됩니다. .txt 파일로 저장하거나 오류 신고에 붙여넣어 주세요."
+    },
+    "keyAlreadyUsed": {
+        "message": "이 단축키는 이미 다른 동작에 지정되어 있습니다. 다른 단축키를 선택해 주세요."
+    },
+    "to": {
+        "message": "부터",
+        "description": "Used between segments. Example: 1:20 to 1:30"
+    },
+    "CopiedExclamation": {
+        "message": "복사 완료!",
+        "description": "Used after something has been copied to the clipboard. Example: 'Copied!'"
+    },
+    "generic_guideline1": {
+        "message": "전환 장면 포함"
+    },
+    "generic_guideline2": {
+        "message": "건너뛴 구간이 없었던 것처럼 자연스럽게 이어지는 영상"
+    },
+    "category_sponsor": {
+        "message": "협찬 광고"
+    },
+    "category_sponsor_description": {
+        "message": "유료 홍보, 추천 및 직접 광고입니다. 자기 홍보나 좋아하는 상품/크리에이터/사이트/제품에 대한 무료 언급은 포함되지 않습니다."
+    },
+    "category_sponsor_guideline1": {
+        "message": "유료 홍보"
+    },
+    "category_sponsor_guideline2": {
+        "message": "후원이나 자체 제작 굿즈는 해당하지 않습니다"
+    },
+    "category_selfpromo": {
+        "message": "무보수/자기 홍보"
+    },
+    "category_selfpromo_description": {
+        "message": "\"협찬 광고\"와 비슷하지만 보수를 받지 않거나 자기 홍보인 경우입니다. 상품, 후원 관련 내용이나 협업자에 대한 정보를 포함합니다."
+    },
+    "category_selfpromo_guideline1": {
+        "message": "후원, 멤버십, 자체 제작 굿즈"
+    },
+    "category_selfpromo_guideline2": {
+        "message": "영상 내용과 무관한 무료 홍보"
+    },
+    "category_selfpromo_guideline3": {
+        "message": "회사가 디자인한 제품이나 굿즈는 해당하지 않습니다"
+    },
+    "category_exclusive_access": {
+        "message": "독점 접근/얼리 액세스"
+    },
+    "category_exclusive_access_description": {
+        "message": "영상 전체를 표시할 때만 사용합니다. 업로더가 무료로 제공받거나 지원받은 제품, 서비스, 장소를 소개하는 영상에 적용됩니다."
+    },
+    "category_exclusive_access_pill": {
+        "message": "이 영상은 업로더가 무료로 제공받거나 지원받은 제품 또는 서비스를 소개하며, 간접 광고, 제품 홍보, 브랜드 홍보를 포함합니다",
+        "description": "此类别的简短描述"
+    },
+    "category_exclusive_access_guideline1": {
+        "message": "영상 전체가 무료 제공/지원 받은 내용을 소개함"
+    },
+    "category_interaction": {
+        "message": "좋아요·코인·팔로우/상호작용 알림"
+    },
+    "category_interaction_description": {
+        "message": "영상 중간에 좋아요, 코인, 팔로우를 눌러달라고 짧게 요청하는 부분입니다. 구간이 길거나 구체적인 내용이 있다면 자기 홍보로 분류해야 합니다."
+    },
+    "category_interaction_guideline1": {
+        "message": "좋아요, 코인, 팔로우를 요청하는 짧은 알림"
+    },
+    "category_interaction_guideline2": {
+        "message": "댓글이나 탄막을 간접적으로 요청하는 경우도 포함"
+    },
+    "category_interaction_guideline3": {
+        "message": "의미 있는 내용을 포함해서는 안 됨"
+    },
+    "category_interaction_short": {
+        "message": "상호작용 알림"
+    },
+    "category_intro": {
+        "message": "전환 장면/오프닝 애니메이션"
+    },
+    "category_intro_description": {
+        "message": "실제 내용이 없는 간격 구간입니다. 일시정지 화면, 정지 프레임, 반복 애니메이션이 해당됩니다. 내용이 포함된 전환 장면에는 적용되지 않습니다."
+    },
+    "category_intro_short": {
+        "message": "오프닝 애니메이션"
+    },
+    "category_intro_guideline1": {
+        "message": "의미 있는 내용을 포함하지 않음"
+    },
+    "category_intro_guideline2": {
+        "message": "내용이 포함된 전환 장면은 제외"
+    },
+    "category_outro": {
+        "message": "크레딧/엔딩 화면"
+    },
+    "category_outro_description": {
+        "message": "크레딧 또는 엔딩 화면입니다. 내용이 없는 마무리 부분입니다."
+    },
+    "category_outro_guideline1": {
+        "message": "크레딧이나 엔딩이 이미 나왔더라도 의미 있는 내용을 포함해서는 안 됩니다"
+    },
+    "category_preview": {
+        "message": "리캡/요약",
+        "description": "https://en.wikipedia.org/wiki/Narrative_hook"
+    },
+    "category_preview_description": {
+        "message": "이 영상 또는 같은 시리즈의 다른 영상에서 나올 장면 모음을 보여주며, 구간에 포함된 모든 내용이 이후 본편에서 다시 등장합니다."
+    },
+    "category_preview_guideline1": {
+        "message": "영상 뒷부분에 다시 나올 구간"
+    },
+    "category_preview_guideline2": {
+        "message": "이전 영상의 리캡 요약"
+    },
+    "category_preview_guideline3": {
+        "message": "새로운 내용을 포함하지 않음"
+    },
+    "category_filler": {
+        "message": "삼천포/농담"
+    },
+    "category_filler_description": {
+        "message": "영상의 주요 내용을 이해하는 데 꼭 필요하지 않은, 그저 분량을 채우거나 재미를 더하기 위한 삼천포 구간입니다. 배경 설명이나 맥락을 제공하는 구간은 포함되지 않습니다. 이는 매우 엄격한 분류로, '오락성' 내용을 보고 싶지 않을 때 사용합니다."
+    },
+    "category_filler_short": {
+        "message": "삼천포"
+    },
+    "category_filler_guideline1": {
+        "message": "시간 끌기/의미 없는 농담 등 삼천포 구간"
+    },
+    "category_filler_guideline2": {
+        "message": "딴 길로 새는 이야기, NG 모음, 재방송"
+    },
+    "category_filler_guideline3": {
+        "message": "주제 이해에 필요하지 않은 구간"
+    },
+    "category_music_offtopic": {
+        "message": "음악: 비음악 부분"
+    },
+    "category_music_offtopic_description": {
+        "message": "음악 영상에만 사용합니다. 다른 카테고리에 포함되지 않는, 음악 영상 중 음악이 아닌 부분에만 사용할 수 있는 분류입니다."
+    },
+    "category_music_offtopic_short": {
+        "message": "비음악"
+    },
+    "category_music_offtopic_guideline1": {
+        "message": "공식 버전에 없는 부분"
+    },
+    "category_music_offtopic_guideline2": {
+        "message": "라이브 공연 중 음악이 아닌 부분"
+    },
+    "category_poi_highlight": {
+        "message": "하이라이트/핵심 순간"
+    },
+    "category_poi_highlight_description": {
+        "message": "대부분의 사람들이 찾고 있는 하이라이트 지점입니다. \"썸네일 장면이 12:34에 나옴\" 같은 댓글과 비슷합니다."
+    },
+    "category_poi_highlight_guideline1": {
+        "message": "대부분의 사람들이 보고 싶어하는 구간"
+    },
+    "category_poi_highlight_guideline2": {
+        "message": "이전 내용을 건너뛰는 데 도움이 될 수 있음"
+    },
+    "category_poi_highlight_guideline3": {
+        "message": "제목이나 썸네일 장면으로 바로 이동할 수 있음"
+    },
+    "category_padding": {
+        "message": "채우기 콘텐츠/암전"
+    },
+    "category_padding_description": {
+        "message": "이식 영상의 시작이나 끝에 있는 순수한 채우기용 콘텐츠로, 검은 화면이나 관련 없는 화면처럼 영상 본편과 실질적인 의미나 연관이 없는 부분입니다."
+    },
+    "category_padding_short": {
+        "message": "채우기 콘텐츠"
+    },
+    "category_padding_guideline1": {
+        "message": "영상 시작이나 끝의 암전 또는 의미 없는 내용"
+    },
+    "category_padding_guideline2": {
+        "message": "이식 영상 중 내용과 무관한 채우기 화면"
+    },
+    "category_livestream_messages": {
+        "message": "라이브 방송: 후원/메시지 읽기"
+    },
+    "category_livestream_messages_short": {
+        "message": "메시지 읽기"
+    },
+    "autoSkip": {
+        "message": "자동 건너뛰기"
+    },
+    "manualSkip": {
+        "message": "수동 건너뛰기"
+    },
+    "showOverlay": {
+        "message": "진행 바에 표시"
+    },
+    "disable": {
+        "message": "비활성화"
+    },
+    "autoSkip_POI": {
+        "message": "자동으로 지점 이동"
+    },
+    "manualSkip_POI": {
+        "message": "영상 로드 시 물어보기"
+    },
+    "showOverlay_POI": {
+        "message": "진행 바에 표시"
+    },
+    "showOverlay_full": {
+        "message": "라벨 표시"
+    },
+    "autoSkipOnMusicVideos": {
+        "message": "모든 음악 영상에서 비음악 구간 자동 건너뛰기"
+    },
+    "danmakuSkip": {
+        "message": "탄막에서 건너뛰기 시점 매칭"
+    },
+    "autoSkipDanmakuSkip": {
+        "message": "매칭 성공 시 자동으로 건너뛰기"
+    },
+    "menuDanmakuSkip": {
+        "message": "매칭 성공 시 제출 창 열기"
+    },
+    "checkTimeDanmakuSkip": {
+        "message": "구간 근처에 이미 업로드된 건너뛰기 정보가 있는지 확인하고, 있으면 이 기능을 실행하지 않음"
+    },
+    "danmakuOffsetMatchingRegexPattern": {
+        "message": "시간 오프셋 매칭 정규식: "
+    },
+    "danmakuOffsetRegexPatternPlaceholder": {
+        "message": "시간 오프셋 지시어와 매칭되는 정규식"
+    },
+    "danmakuOffsetRegexTitle": {
+        "message": "시간 오프셋 지시어와 매칭되는 정규식을 입력해 주세요. 정규식 작성법을 잘 모른다면 이 항목을 수정하지 마세요"
+    },
+    "danmakuOffsetRegexPatternDescription": {
+        "message": "\"오른쪽으로 12칸\", \"우측 방향 34번\" 등의 형식과 유사한 탄막을 매칭하여 건너뛰기 시점을 계산합니다."
+    },
+    "muteSegments": {
+        "message": "건너뛰기 대신 구간 음소거 허용"
+    },
+    "fullVideoSegments": {
+        "message": "영상 전체가 특정 카테고리일 때 아이콘 표시",
+        "description": "Referring to the category pill that is now shown on videos that are entirely sponsor or entirely selfpromo"
+    },
+    "fullVideoLabelsOnThumbnailsMode": {
+        "message": "영상 전체가 특정 카테고리일 때, 영상 카드에서",
+        "description": "Referring to the category pill that is shown on videos that are entirely sponsor or entirely selfpromo on recommended videos, in searches or on the homepage."
+    },
+    "fullVideoLabelsOnThumbnailsMode0": {
+        "message": "동작 없음"
+    },
+    "fullVideoLabelsOnThumbnailsMode1": {
+        "message": "라벨 표시"
+    },
+    "fullVideoLabelsOnThumbnailsMode2": {
+        "message": "이 영상 카드 숨기기 - 권장하지 않음"
+    },
+    "fullVideoLabelsOnThumbnailsMode2_Warning": {
+        "message": "이 옵션은 관심 있는 영상을 포함해 많은 영상 카드를 숨기며, 레이아웃에도 영향을 줄 수 있으니 신중하게 사용해 주세요.\n숨겨진 영상에는 어떤 표시도 남지 않으며, 수동으로 다시 볼 수도 없습니다.\n대신 \"이 영상 카드 흐리게 처리 - 마우스를 올리면 내용 확인 가능\"을 사용하는 것을 권장합니다."
+    },
+    "fullVideoLabelsOnThumbnailsMode3": {
+        "message": "이 영상 카드 흐리게 처리 - 마우스를 올리면 내용 확인 가능"
+    },
+    "fullVideoLabelsOnThumbnailsMode4": {
+        "message": "이 영상 카드 흐리게 처리"
+    },
+    "fullVideoLabelsOnThumbnailsMode5": {
+        "message": "이 영상 카드 가리기 - 권장하지 않음"
+    },
+    "fullVideoBlock": {
+        "message": ""
+    },
+    "previewColor": {
+        "message": "미제출 색상",
+        "description": "Referring to submissions that have not been sent to the server yet."
+    },
+    "seekBarColor": {
+        "message": "진행 바 색상"
+    },
+    "category": {
+        "message": "카테고리"
+    },
+    "skipOption": {
+        "message": "건너뛰기 옵션",
+        "description": "Used on the options page to describe the ways to skip the segment (auto skip, manual, etc.)"
+    },
+    "enableTestingServer": {
+        "message": "베타 테스트 서버 사용"
+    },
+    "whatEnableTestingServer": {
+        "message": "제출 및 투표 내용이 메인 서버에는 반영되지 않습니다. 테스트 용도로만 사용됩니다."
+    },
+    "testingServerWarning": {
+        "message": "테스트 서버에 연결된 동안에는 모든 제출과 투표가 메인 서버에 반영되지 않습니다. 실제로 제출하려면 이 옵션이 꺼져 있는지 꼭 확인하세요."
+    },
+    "bracketNow": {
+        "message": "[현재 시점으로 설정]"
+    },
+    "moreCategories": {
+        "message": "더 많은 카테고리"
+    },
+    "chooseACategory": {
+        "message": "카테고리 선택"
+    },
+    "enableThisCategoryFirst": {
+        "message": "\"{0}\" 카테고리의 구간을 제출하려면 옵션에서 이 카테고리를 먼저 활성화해야 합니다. 지금 옵션 페이지로 이동합니다.",
+        "description": "Used when submitting segments to only let them select a certain category if they have it enabled in the options."
+    },
+    "poiOnlyOneSegment": {
+        "message": "경고: 이 유형의 구간은 한 번에 하나만 사용할 수 있습니다. 여러 개를 제출하면 무작위로 표시됩니다."
+    },
+    "youMustSelectACategory": {
+        "message": "제출하려는 모든 구간에 카테고리를 선택해야 합니다!"
+    },
+    "bracketStart": {
+        "message": "[영상 시작]"
+    },
+    "bracketEnd": {
+        "message": "[영상 끝]"
+    },
+    "End": {
+        "message": "구간 끝",
+        "description": "Button that skips to the end of a segment"
+    },
+    "hiddenDueToDownvote": {
+        "message": "숨김: 싫어요"
+    },
+    "hiddenDueToDuration": {
+        "message": "숨김: 너무 짧음"
+    },
+    "manuallyHidden": {
+        "message": "수동으로 숨김"
+    },
+    "channelDataNotFound": {
+        "message": "업로더 ID를 감지하지 못했습니다. 임베드된 플레이어를 사용 중이라면 사이트에서 직접 시청해 주세요. 사이트가 페이지 레이아웃을 변경했을 수도 있으니, 이 문제라고 생각되면 여기에 댓글을 남겨 주세요:",
+        "description": "This error appears in an alert when they try to whitelist a channel and the extension is unable to determine what channel they are looking at."
+    },
+    "invidiousPermissionRefresh": {
+        "message": "브라우저가 Invidious 및 기타 서드파티 사이트에서 실행하는 데 필요한 권한을 취소했습니다. 아래 버튼을 클릭해 권한을 다시 활성화해 주세요."
+    },
+    "acceptPermission": {
+        "message": "권한 허용"
+    },
+    "permissionRequestSuccess": {
+        "message": "권한 요청 성공!"
+    },
+    "permissionRequestFailed": {
+        "message": "권한 요청 실패, 거부를 클릭하신 건 아닌가요?"
+    },
+    "forceChannelCheck": {
+        "message": "건너뛰기 전 채널 확인 강제 실행"
+    },
+    "whatForceChannelCheck": {
+        "message": "기본적으로 현재 채널이 아직 확인되지 않았더라도 구간을 즉시 건너뜁니다. 이 때문에 화이트리스트에 등록된 업로더의 영상이라도 시작 부분의 일부 구간이 건너뛰어질 수 있습니다. 이 옵션을 켜면 이런 상황을 방지할 수 있지만, 채널 ID를 가져오는 데 약간의 시간이 걸리므로 모든 건너뛰기에 약간의 지연이 생깁니다. 네트워크 속도가 빠르다면 지연은 매우 짧을 것입니다."
+    },
+    "forceChannelCheckPopup": {
+        "message": "\"건너뛰기 전 채널 확인 강제 실행\"을 활성화하는 것을 고려해 보세요"
+    },
+    "downvoteDescription": {
+        "message": "잘못된/부정확한 시간"
+    },
+    "incorrectVote": {
+        "message": "부정확함"
+    },
+    "harmfulVote": {
+        "message": "유해함",
+        "description": "Used for chapter segments when the text is harmful/offensive to remove it faster"
+    },
+    "incorrectCategory": {
+        "message": "카테고리 변경"
+    },
+    "nonMusicCategoryOnMusic": {
+        "message": "이 영상은 음악으로 분류되어 있습니다. 정말 협찬 광고가 포함되어 있나요? 만약 \"비음악 구간\"이라면 확장 프로그램 옵션을 열어 이 카테고리를 활성화해 주세요. 그런 다음 협찬 광고 대신 \"비음악\" 카테고리로 이 구간을 제출할 수 있습니다. 잘 모르겠다면 가이드라인을 읽어 주세요."
+    },
+    "multipleSegments": {
+        "message": "여러 구간"
+    },
+    "guidelines": {
+        "message": "가이드라인"
+    },
+    "readTheGuidelines": {
+        "message": "가이드라인을 꼭 읽어주세요!!",
+        "description": "Show the first time they submit or if they are \"high risk\""
+    },
+    "skipFrameShortcutPopupLine1": {
+        "message": "정확한 지점을 찾기 어려우신가요? \",\"와 \".\" 키로 이전/다음 프레임으로 이동해 보세요!"
+    },
+    "skipFrameShortcutPopupLine2": {
+        "message": "(이 단축키는 팝업이 열려 있을 때만 사용할 수 있으며, 단축키 지정은 {0}에서 변경할 수 있습니다)"
+    },
+    "optionsPage": {
+        "message": "옵션 페이지"
+    },
+    "categoryUpdate1": {
+        "message": "카테고리 기능이 추가되었습니다!"
+    },
+    "categoryUpdate2": {
+        "message": "오프닝, 엔딩, 광고 등을 건너뛰려면 옵션을 켜세요."
+    },
+    "help": {
+        "message": "도움말"
+    },
+    "GotIt": {
+        "message": "확인했습니다",
+        "description": "Used as the button to dismiss a tooltip"
+    },
+    "fullVideoTooltipWarning": {
+        "message": "구간이 너무 깁니다. 영상 전체가 같은 주제를 다루고 있다면 \"건너뛰기\" 대신 \"영상 전체\" 라벨로 변경해 주세요. 자세한 내용은 가이드라인을 확인하세요."
+    },
+    "categoryPillTitleText": {
+        "message": "영상 전체가 이 카테고리로 표시되어 있으며 내용이 너무 밀집되어 있어 분리할 수 없습니다."
+    },
+    "chapterNameTooltipWarning": {
+        "message": "제출하려는 챕터 이름이 기존 카테고리 이름과 비슷합니다. 이미 존재하는 분류가 있다면 그것을 우선 사용해야 합니다."
+    },
+    "experimentOptOut": {
+        "message": "모든 실험적 기능 끄기",
+        "description": "This is used in a popup about a new experiment to get a list of unlisted videos to back up since all unlisted videos uploaded before 2017 will be set to private."
+    },
+    "hideForever": {
+        "message": "영원히 숨기기"
+    },
+    "warningChatInfo": {
+        "message": "몇 가지 흔한 실수를 발견했습니다. 지금까지 해주신 작업에 매우 감사드리지만, 저희는 완벽을 추구하기 때문에 아주 작은 실수라도 신경 써야 합니다 :)"
+    },
+    "questionButton": {
+        "message": "질문이 있어요"
+    },
+    "askAQuestion": {
+        "message": "질문하기"
+    },
+    "warningConfirmButton": {
+        "message": "이유를 이해했습니다"
+    },
+    "warningError": {
+        "message": "경고를 확인하는 중 오류가 발생했습니다: "
+    },
+    "deArrowMessageReceived": {
+        "message": "운영진으로부터 안내를 받았습니다"
+    },
+    "Donate": {
+        "message": "후원"
+    },
+    "considerDonating": {
+        "message": "개발 후원하기"
+    },
+    "hideDonationLink": {
+        "message": "후원 링크 숨기기"
+    },
+    "darkModeOptionsPage": {
+        "message": "옵션 페이지 다크 모드"
+    },
+    "LearnMore": {
+        "message": "자세히 알아보기"
+    },
+    "FullDetails": {
+        "message": "전체 세부 정보"
+    },
+    "CopyDownvoteButtonInfo": {
+        "message": "싫어요를 누르고 다시 제출할 수 있도록 로컬 사본 생성"
+    },
+    "OpenCategoryWikiPage": {
+        "message": "이 카테고리의 위키 페이지를 엽니다."
+    },
+    "CopyAndDownvote": {
+        "message": "복사하고 싫어요"
+    },
+    "ContinueVoting": {
+        "message": "투표 계속하기"
+    },
+    "ChangeCategoryTooltip": {
+        "message": "이 작업은 즉시 모든 구간에 적용됩니다"
+    },
+    "downvote": {
+        "message": "싫어요"
+    },
+    "upvote": {
+        "message": "좋아요"
+    },
+    "hideSegment": {
+        "message": "구간 숨기기"
+    },
+    "skipSegment": {
+        "message": "구간 건너뛰기"
+    },
+    "playChapter": {
+        "message": "챕터 재생"
+    },
+    "SponsorTimeEditScrollNewFeature": {
+        "message": "편집 상자에 마우스를 올리고 휠을 돌리면 시간을 빠르게 조정할 수 있습니다. Ctrl, Shift와 함께 사용하면 시간을 미세하게 조정할 수 있습니다."
+    },
+    "categoryPillNewFeature": {
+        "message": "새 기능! 영상이 완전히 협찬 광고이거나 자기 홍보인지 바로 알 수 있습니다"
+    },
+    "yearAbbreviation": {
+        "message": "년",
+        "description": "100y"
+    },
+    "dayAbbreviation": {
+        "message": "일",
+        "description": "100d"
+    },
+    "hourAbbreviation": {
+        "message": "시간",
+        "description": "100h"
+    },
+    "optionsTabBehavior": {
+        "message": "동작",
+        "description": "Appears in Options as a tab header for options related to categories and skipping behavior. To fit inside the button, it should not be longer than ~20-25 characters (depending on their width)."
+    },
+    "optionsTabInterface": {
+        "message": "인터페이스",
+        "description": "Appears in Options as a tab header for options related to GUI and sounds. To fit inside the button, it should not be longer than ~20-25 characters (depending on their width)."
+    },
+    "optionsTabKeyBinds": {
+        "message": "단축키",
+        "description": "Appears in Options as a tab header for keybinds. To fit inside the button, it should not be longer than ~20-25 characters (depending on their width)."
+    },
+    "optionsTabBackup": {
+        "message": "백업/복원",
+        "description": "Appears in Options as a tab header for options related to saving/restoring your settings. To fit inside the button, it should not be longer than ~20-25 characters (depending on their width)."
+    },
+    "optionsTabAdvanced": {
+        "message": "기타",
+        "description": "Appears in Options as a tab header for advanced/niche options. To fit inside the button, it should not be longer than ~20-25 characters (depending on their width)."
+    },
+    "optionsTabExperiment": {
+        "message": "실험 기능"
+    },
+    "noticeVisibilityLabel": {
+        "message": "건너뛰기 알림 표시 방식",
+        "description": "Option label"
+    },
+    "unbind": {
+        "message": "지정 해제",
+        "description": "Unbind keyboard shortcut"
+    },
+    "notSet": {
+        "message": "설정되지 않음"
+    },
+    "change": {
+        "message": "변경"
+    },
+    "bilibiliKeybindWarning": {
+        "message": "이것은 사이트에 내장된 단축키입니다. 정말 사용하시겠습니까?"
+    },
+    "betaServerWarning": {
+        "message": "테스트 서버가 활성화되어 있습니다!"
+    },
+    "openOptionsPage": {
+        "message": "옵션 페이지 열기"
+    },
+    "resetToDefault": {
+        "message": "모든 설정 초기화"
+    },
+    "confirmResetToDefault": {
+        "message": "모든 설정을 기본값으로 초기화하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+    },
+    "exportSegments": {
+        "message": "구간 내보내기"
+    },
+    "importSegments": {
+        "message": "구간 가져오기"
+    },
+    "Import": {
+        "message": "가져오기",
+        "description": "Button to initiate importing segments. Appears under the textbox where they paste in the data"
+    },
+    "disclaimer": {
+        "message": "모든 구간은 사용자가 제출하며, 사용자 투표로 정렬됩니다"
+    },
+    "hideNewFeatureUpdates": {
+        "message": "새 기능 안내 숨기기"
+    },
+    "unsubmittedSegmentCounts": {
+        "message": "{1}에 {0}이(가) 있습니다",
+        "description": "Example: You currently have 12 unsubmitted segments on 5 videos"
+    },
+    "unsubmittedSegmentCountsZero": {
+        "message": "현재 제출되지 않은 구간이 없습니다",
+        "description": "Replaces 'unsubmittedSegmentCounts' string when there are no unsubmitted segments"
+    },
+    "unsubmittedSegmentsSingular": {
+        "message": "제출되지 않은 구간",
+        "description": "Example: You currently have 1 *unsubmitted segment* on 1 video"
+    },
+    "unsubmittedSegmentsPlural": {
+        "message": "제출되지 않은 구간",
+        "description": "Example: You currently have 12 *unsubmitted segments* on 5 videos"
+    },
+    "videosSingular": {
+        "message": "영상",
+        "description": "Example: You currently have 3 unsubmitted segments on 1 *video*"
+    },
+    "videosPlural": {
+        "message": "영상",
+        "description": "Example: You currently have 12 unsubmitted segments on 5 *videos*"
+    },
+    "clearUnsubmittedSegments": {
+        "message": "모든 구간 지우기",
+        "description": "Label for a button in settings"
+    },
+    "clearUnsubmittedSegmentsConfirm": {
+        "message": "제출되지 않은 모든 구간을 지우시겠습니까?",
+        "description": "Confirmation message for the Clear unsubmitted segments button"
+    },
+    "showUnsubmittedSegments": {
+        "message": "구간 표시",
+        "description": "Show/hide button for the unsubmitted segments list"
+    },
+    "hideUnsubmittedSegments": {
+        "message": "구간 숨기기",
+        "description": "Show/hide button for the unsubmitted segments list"
+    },
+    "videoID": {
+        "message": "영상 ID",
+        "description": "Header of the unsubmitted segments list"
+    },
+    "segmentCount": {
+        "message": "구간 수",
+        "description": "Header of the unsubmitted segments list"
+    },
+    "actions": {
+        "message": "작업",
+        "description": "Header of the unsubmitted segments list"
+    },
+    "exportSegmentsAsURL": {
+        "message": "링크 공유"
+    },
+    "segmentFetchFailureWarning": {
+        "message": "경고: 서버가 응답하지 않습니다. 구간이 이미 제출되었을 수 있지만, 서버 문제로 응답을 받지 못했을 수 있습니다."
+    },
+    "allowScrollingToEdit": {
+        "message": "휠로 시간 편집 허용"
+    },
+    "showPreviewYoutubeButton": {
+        "message": "이식 영상 영역에 \"유튜브 영상 미리보기\" 버튼 표시"
+    },
+    "showPortVideoButton": {
+        "message": "이식 영상 연동 버튼 표시"
+    },
+    "NoticeTimeAfterSkip": {
+        "message": "{seconds}초",
+        "description": "This is used on the popup to show how much time left. It will look like \"5s\". The word {seconds} will be replaced, so keep it here. Translations should only change the \"s\""
+    },
+    "FillerWarning": {
+        "message": "경고: 이는 매우 엄격한 분류입니다. 일부 구간은 건너뛰기를 취소해야 할 수도 있고, 때로는 이 기능을 꺼야 할 수도 있습니다. 많은 영상에서 건너뛰기 비율이 50%를 넘거나 그 이상일 수 있다는 점을 유의해 주세요! 다만 제출 시에는 여전히 특정 가이드라인을 따라야 한다는 것을 기억해 주세요.",
+        "description": "Warning that appears when enabling the filler tangent category"
+    },
+    "cleanPopup": {
+        "message": "팝업 내용 단순화"
+    },
+    "syncDisabledWarning": {
+        "message": "경고: 브라우저에서 확장 프로그램 저장소가 비활성화되어 있습니다. 설정을 저장하려고 해도 저장되지 않습니다."
+    },
+    "syncDisabledWarningDeArrow": {
+        "message": "DeArrow는 저장소 없이는 작동하지 않습니다."
+    },
+    "syncDisabledFirefoxSuggestions": {
+        "message": "about:config로 이동해 \"webextensions.storage.sync.enabled\" 값을 true로 설정하면 활성화할 수 있습니다."
+    },
+    "storageFull": {
+        "message": "확장 프로그램 저장 공간이 가득 찼습니다. 옵션에서 제출되지 않은 구간 일부를 삭제해 주세요."
+    },
+    "previewSegmentRequired": {
+        "message": "제출하기 전에 구간을 미리보기 해주세요. 단축키로 미리보기를 할 수 있습니다: ",
+        "description": "Appears when trying to submit a segment without previewing it first. After the colon, the shortcut will appear"
+    },
+    "hasBoundPortVideo": {
+        "message": "연동된 영상: "
+    },
+    "enterPortVideoURL": {
+        "message": "이식 영상 주소를 입력해 주세요"
+    },
+    "previewYoutubeVideoButton": {
+        "message": "유튜브 영상 미리보기"
+    },
+    "bindPortVideoButton": {
+        "message": "이식 영상 연동"
+    },
+    "refreshPortedSegments": {
+        "message": "연동된 영상의 구간 업데이트"
+    },
+    "refreshSuccess": {
+        "message": "업데이트 성공!"
+    },
+    "refreshFailed": {
+        "message": "업데이트 실패!"
+    },
+    "bindPortVideo": {
+        "message": "이식 영상 동기화"
+    },
+    "dynamicAndCommentSponsorBlocker": {
+        "message": "타임라인/댓글 영역의 상품 링크 숨기기"
+    },
+    "dynamicAndCommentSponsorBlockerDescription": {
+        "message": "상품 링크란 타임라인/댓글 영역에서 홍보 내용을 포함하는 게시물/댓글을 의미합니다"
+    },
+    "dynamicSpaceSponsorBlocker": {
+        "message": "업로더 홈 타임라인 내용 숨기기"
+    },
+    "dynamicSpaceSponsorBlockerDescription": {
+        "message": "업로더 홈 타임라인의 상품 링크도 숨겨집니다. 업로더의 전체 타임라인을 편하게 보기 위해서는 켜지 않는 것을 권장합니다"
+    },
+    "dynamicAndCommentSponsorWhitelistedChannels": {
+        "message": "화이트리스트 무시"
+    },
+    "dynamicAndCommentSponsorWhitelistedChannelsDescription": {
+        "message": "화이트리스트에 등록된 업로더라도 해당 내용을 숨깁니다"
+    },
+    "dynamicSponsorShow": {
+        "message": "링크 내용 표시"
+    },
+    "dynamicSponsorHide": {
+        "message": "링크 내용 숨기기"
+    },
+    "dynamicAndCommentSponsorRegexPattern": {
+        "message": "차단 매칭 정규식: "
+    },
+    "dynamicAndCommentSponsorRegexPatternDescription": {
+        "message": "기본 정규식은 다소 보수적으로 설정되어 있으니, 관심 있는 업로더의 타임라인 내용에 맞게 직접 수정하는 것을 권장합니다(정규식 작성이 가능하다면).\n예를 들어 관심 있는 업로더가 특정 상품의 광고를 자주 올린다면, 해당 상품명을 정규식에 추가할 수 있습니다"
+    },
+    "category_dynamicSponsor_sponsor": {
+        "message": "상품 링크"
+    },
+    "category_dynamicSponsor_sponsor_description": {
+        "message": "상품 링크를 포함하는 경우입니다. 일부 간접 광고는 링크가 없거나 표준 형식이 아닐 수 있어 현재로서는 완전히 차단할 수 없습니다"
+    },
+    "category_dynamicSponsor_forward_sponsor": {
+        "message": "상품 링크 리포스트"
+    },
+    "category_dynamicSponsor_forward_sponsor_description": {
+        "message": "리포스트한 게시물이 상품 링크를 포함한 업로더의 게시물일 경우, 해당 게시물은 \"상품 링크 리포스트\"로 간주됩니다"
+    },
+    "category_dynamicSponsor_suspicion_sponsor": {
+        "message": "상품 링크 의심"
+    },
+    "category_dynamicSponsor_suspicion_sponsor_description": {
+        "message": "정규식으로 내용을 매칭해 은근한 홍보를 추가로 차단합니다. \"상품 링크\"를 보완하는 기능으로, 일부 내용을 잘못 차단하거나 놓칠 수 있습니다"
+    },
+    "showOverlay_DynamicSponsor": {
+        "message": "라벨만 추가"
+    },
+    "Hide_DynamicSponsor": {
+        "message": "내용 숨기기"
+    },
+    "skipOptionDynamicSponsor": {
+        "message": "옵션"
+    },
+    "colorDynamicSponsor": {
+        "message": "라벨 색상"
+    },
+    "DynamicSponsorMatch": {
+        "message": " 키워드: ",
+        "tip": "공백은 구분자로 사용됩니다"
+    },
+    "dynamicSponsorBlockerDebug": {
+        "message": "상품 링크 의심 매칭 텍스트 표시 / 정규식 디버그 모드"
+    },
+    "dynamicSponsorBlockerDebugDescription": {
+        "message": "라벨에 마우스를 올리면 매칭된 텍스트를 표시합니다"
+    },
+    "commentSponsorBlock": {
+        "message": "댓글 영역 숨기기 사용"
+    },
+    "commentSponsorBlockDescription": {
+        "message": "댓글 영역은 현재 \"상품 링크\" 카테고리만 지원합니다"
+    },
+    "dynamicSponsorBlock": {
+        "message": "타임라인 숨기기 사용"
+    },
+    "dynamicSponsorBlockDescription": {
+        "message": "타임라인은 모든 카테고리를 지원합니다 (영상 제외)"
+    },
+    "commentSponsorReplyBlock": {
+        "message": "\"상품 링크\" 댓글의 인기 답글 숨기기"
+    },
+    "commentSponsorReplyBlockDescription": {
+        "message": "이 옵션을 켜면 \"상품 링크\" 댓글 아래 기본으로 표시되는 답글이 숨겨집니다\n숨겨진 답글이라도 전체 댓글 펼치기 기능으로 계속 확인할 수 있습니다"
+    },
+    "requestVote": {
+        "message": "이 구간 표시가 정확한가요?"
+    },
+    "whitelistManagement": {
+        "message": "화이트리스트 관리"
+    },
+    "whitelistCount": {
+        "message": "화이트리스트에 업로더 {0}명이 있습니다"
+    },
+    "whitelistCountZero": {
+        "message": "화이트리스트가 비어 있습니다"
+    },
+    "showWhitelist": {
+        "message": "화이트리스트 표시"
+    },
+    "hideWhitelist": {
+        "message": "화이트리스트 숨기기"
+    },
+    "clearWhitelist": {
+        "message": "화이트리스트 비우기"
+    },
+    "clearWhitelistConfirm": {
+        "message": "화이트리스트를 모두 비우시겠습니까?"
+    },
+    "removeFromWhitelistConfirm": {
+        "message": "이 업로더를 화이트리스트에서 제거하시겠습니까?"
+    },
+    "whitelistUploaderName": {
+        "message": "업로더 이름"
+    },
+    "whitelistUploaderId": {
+        "message": "UID"
+    },
+    "whitelistActions": {
+        "message": "작업"
+    },
+    "whitelistRemove": {
+        "message": "제거"
+    },
+    "whitelistEmptyHint": {
+        "message": "화이트리스트가 비어 있습니다. 영상 페이지에서 업로더를 화이트리스트에 추가할 수 있습니다"
+    },
+    "whitelistUnknownUploader": {
+        "message": "알 수 없는 업로더"
+    },
+    "danmakuMatchingTitle": {
+        "message": "탄막 매칭"
+    },
+    "cacheManagementTitle": {
+        "message": "캐시 관리"
+    },
+    "lifecycleDebug": {
+        "message": "디버그 로그를 콘솔에 출력"
+    },
+    "lifecycleDebugDescription": {
+        "message": "꺼져 있으면 로그가 페이지 메모리에만 보관되며, 켜면 라이프사이클 및 디버그 로그를 콘솔에도 추가로 출력합니다."
+    },
+    "copyPageLogs": {
+        "message": "페이지 로그 복사"
+    },
+    "copyPageLogsSuccess": {
+        "message": "현재 페이지 로그가 복사되었습니다"
+    },
+    "copyPageLogsFailed": {
+        "message": "페이지 로그 복사 실패"
+    }
+}


### PR DESCRIPTION
## Motivation

This adds Korean (`ko`) translation support — to help Korean-speaking users use this
open-source project more comfortably in their own language.

한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.

## Changes

- Added `public/_locales/ko/messages.json` with all 469 keys translated to Korean.
- No `manifest.json` changes needed (locale is auto-discovered from `_locales/`).
- `ko` is intentionally left out of the Edge-specific `edgeLanguages` allowlist in `webpack/webpack.common.js`, matching the existing `zh_TW` precedent (Edge builds only bundle a curated subset of locales; Chrome/Firefox builds pick up all locales automatically).

## Testing

- Verified key parity programmatically against `en/messages.json`: 469/469 keys present, 0 missing/extra.
- Verified all `{0}`/`{1}`/`{seconds}` placeholders and `\n` newlines are preserved 1:1 between `en` and `ko`.
- Spot-checked translation quality, including the marketing copy in `Description`/`longDescription` and Bilibili-specific terms (업로더 for UP主, 탄막 for 弹幕, 이식 영상 for 搬运 video).
- Confirmed brand names `小电视空降助手`/`空降助手` were left untranslated, consistent with the `zh_TW` locale convention.
